### PR TITLE
Devel

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -3846,7 +3846,7 @@ generate_ssl_key_and_csr() {
 
 check_certificates() {
     echo "check_certificates..."
-	source ${esg_functions_file}
+    source ${esg_functions_file}
     check_cert_expiry_for_files ${tomcat_conf_dir}/${esgf_host:-$(hostname --fqdn)}-esg-node.pem
     (source ${scripts_dir}/esg-globus && globus_check_certificates $@)
 }


### PR DESCRIPTION
esg-node has an option '--check-certs' to check whether the certificates
(globus and tomcat certs) are valid or not. This invokes the
check_cert_expiry function from the file esg-functions.
The trouble is that there are four declare statements which don't get read
in before this function is called, when checking for the tomcat certs.

The declare statements read thus:
declare -r expired=0
declare -r day=$((60_60_24))
declare -r warn=$((day_7))
declare -r info=$((day_30))

When these variables are not initialized, the openssl x509 command
doesn't get the required argument and returns an error. At this point,
the script decides erroneously that the certificate has expired and
proceeds to trash the perfectly valid certificate.

The test for the globus certificate doesn't run into this problem as
the esg-globus script sources esg-functions before making the call to
check_cert_expiry.

I've fixed the problem by sourcing esg-functions before calling check_cert_expiry_for_files in esg-node.
