### PR TITLE
up publisher version

### DIFF
--- a/esg-init
+++ b/esg-init
@@ -27,8 +27,8 @@ init() {
     cdat_version=${cdat_version:-"2.2.0"}
 #    cdat_tag="1.5.1.esgf-v1.7.0"
 
-    esgcet_version=${esgcet_version:-"2.13.0"}
-    publisher_tag=${publisher_tag:-"v2.13.0"}
+    esgcet_version=${esgcet_version:-"2.13.1"}
+    publisher_tag=${publisher_tag:-"v2.13.1"}
 
     #see esgf-node-manager project:
     esgf_node_manager_version=${esgf_node_manager_version:-"0.7.1"}


### PR DESCRIPTION
This version fixes the problems I was having with the thredds reinit and index publishing.
thredds.py switch to httplib + basic auth in header.