### PR TITLE
Possible help for TDS 5 migration

### DIFF
--- a/esg-functions
+++ b/esg-functions
@@ -593,12 +593,14 @@ start_tomcat() {
 
     pushd $tomcat_install_dir >& /dev/null
     [ $((sel & ALL_BIT)) != 0 ] && java_opts=" -Xmx2048m -server -Xms1024m -XX:MaxPermSize=512m $java_opts"
-    jsvc_launch_command="JAVA_HOME=$java_install_dir ${tomcat_install_dir}/bin/jsvc -Djava.awt.headless=true -Dcom.sun.enterprise.server.ss.ASQuickStartup=false -Dcatalina.home=${tomcat_install_dir} -pidfile $tomcat_pid_file -cp $(find $(readlink -f `pwd`/bin/) | grep jar | xargs | perl -pe 's/ /:/g') -outfile ${tomcat_install_dir}/logs/catalina.out -errfile ${tomcat_install_dir}/logs/catalina.err -user $tomcat_user $tomcat_opts $java_opts -Dsun.security.ssl.allowUnsafeRenegotiation=false org.apache.catalina.startup.Bootstrap"
+    jsvc_launch_command="JAVA_HOME=$java_install_dir ${tomcat_install_dir}/bin/jsvc -Djava.awt.headless=true -Dcom.sun.enterprise.server.ss.ASQuickStartup=false -Dcatalina.home=${tomcat_install_dir} -pidfile $tomcat_pid_file -cp $(find $(readlink -f `pwd`/bin/) | grep jar | xargs | perl -pe 's/ /:/g') -outfile ${tomcat_install_dir}/logs/catalina.out -errfile ${tomcat_install_dir}/logs/catalina.err -user $tomcat_user $tomcat_opts $java_opts -Dsun.security.ssl.allowUnsafeRenegotiation=false org.apache.catalina.startup.Bootstrap -Dtds.content.root.path=/esg/content -Djava.util.prefs.userRoot=/esg/content/thredds/javaUtilPrefs"
     echo "$jsvc_launch_command"
     JAVA_HOME=${java_install_dir} ./bin/jsvc \
         -Djava.awt.headless=true \
         -Dcom.sun.enterprise.server.ss.ASQuickStartup=false \
         -Dcatalina.home=${tomcat_install_dir} \
+        -Dtds.content.root.path=/esg/content \
+	-Djava.util.prefs.userRoot=/esg/content/thredds/javaUtilPrefs \
         -pidfile ${tomcat_pid_file} \
         -cp $(find $(readlink -f `pwd`/bin/) | grep .jar | xargs | perl -pe 's/ /:/g') \
         -outfile ${tomcat_install_dir}/logs/catalina.out \

--- a/esg-init
+++ b/esg-init
@@ -66,7 +66,7 @@ init() {
     postgress_version=${postgress_version:-"9.4.4"} ; postgress_min_version=${postgress_min_version:-"9.4.4"}
     tomcat_version=${tomcat_version:-"7.0.63"} ; tomcat_min_version=${tomcat_min_version:-"7.0.63"}
     #cmake_version=${cmake_version:="2.8.12.2"} ; cmake_min_version=${cmake_min_version:="2.8.10.2"} ; cmake_max_version=${cmake_max_version:="2.8.12.2"}
-    tds_version=${tds_version:-"4.3.17"} ; tds_min_version=${tds_min_version:-"4.3.17"}
+    tds_version=${tds_version:-"4.6.2"} ; tds_min_version=${tds_min_version:-"4.3.17"}
 
     # Since ESGF 1.8, LAS version is declared in esg-product-server
     #las_version=${las_version:-"8.1"}; las_min_version=${las_min_version:-"8.1"}

--- a/esg-node
+++ b/esg-node
@@ -80,7 +80,9 @@ custom=0
 use_local_files=0
 
 progname="esg-node"
+
 script_version="v2.0-RC3.2-devel"
+
 script_maj_version="2.0"
 script_release="Centaur"
 envfile="/etc/esg.env"
@@ -2483,19 +2485,6 @@ setup_tds() {
 
     #See thredds_content_dir set in init() - default value is ${esg_root_dir}/content
 
-    #--------
-    #EDIT the thredds property file: ${tomcat_install_dir}/webapps/thredds/WEB-INF/classes/thredds/server/tds.properties
-    #replace the value for token "tds..content.root.path" with ${thredds_content_dir}
-    local thredds_property_file=${tomcat_install_dir}/webapps/thredds/WEB-INF/classes/thredds/server/tds.properties
-    if [ -e "${thredds_property_file}" ]; then
-        sed -i.bak -e 's#tds.content.root.path=.*#tds.content.root.path='${thredds_content_dir}'#' ${thredds_property_file}
-        chown -R ${tomcat_user}:${tomcat_group} ${thredds_property_file}
-        chmod 644 ${thredds_property_file}
-        echo "configured thredds content root -> $(egrep -e 'tds.content.root.path=.*' ${thredds_property_file})"
-    else
-        echo "WARNING: Could not file thredds' property file: ${thredds_property_file}"
-    fi
-
     echo "Please set the thredds content directory to: ${thredds_content_dir} in the following setup"
     #--------
 
@@ -2566,11 +2555,12 @@ setup_tds() {
         : $((wait_time--))
     done
 
-    append_esgf_log4j_entries ${tomcat_install_dir}/webapps/thredds/WEB-INF/log4j.xml
+
+#    append_esgf_log4j_entries ${tomcat_install_dir}/webapps/thredds/WEB-INF/log4j.xml
 
     #Move over XSLT files... (see Nicolas' email(ncarenton...fr) subj="ESGF1.5.0 TDS4.3.16" date:"5/27/13 8:30 AM PDT")
     cp -v ${tomcat_install_dir}/webapps/thredds/WEB-INF/xsl/ncssGrid* ${tomcat_install_dir}/webapps/thredds/WEB-INF/classes/resources/xsl/
-    cp -vp ${tomcat_install_dir}/webapps/thredds/WEB-INF/altContent/idd/thredds/wmsConfig.xml ${thredds_content_dir}/thredds/
+    cp -vp ${tomcat_install_dir}/webapps/thredds/WEB-INF/altContent/startup/wmsConfig.xml ${thredds_content_dir}/thredds/
 
     [ $? != 0 ] && [FAIL] && echo " ERROR: Not able to contact thredds page on this server" && checked_done 1
     [OK]

--- a/filters/esg-security-tokenless-filters
+++ b/filters/esg-security-tokenless-filters
@@ -204,7 +204,7 @@ get_orp_libs() {
     #------------------------------------------------------------------
     #NOTE: Make sure that this version matches the version that is in
     #the esg-orp project!!!
-    spring_version=${spring_version:-"3.2.2.RELEASE"}
+    spring_version=${spring_version:-"4.1.6.RELEASE"}
     #------------------------------------------------------------------
 
     #----------------------------


### PR DESCRIPTION
These were several changes that I found were needed for Thredds 4.6.  
TDS no longer uses tds.properties to specify /esg/content/  as this is added to the startup command
remove log4j
new location for wmsConfig.xml
update filters to Spring 4.1.6 so Spring 3.2.2 jars don't get installed (this broke my TDS before)
