### PR TITLE
Fix Globus tests

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -2709,11 +2709,11 @@ test_publication() {
     echo "X509_USER_KEY  = [${_X509_USER_KEY}]"
     echo "X509_USER_CERT = [${_X509_USER_CERT}]"
     echo "----------"
-    echo "$globus_location/bin/myproxy-logon -s $myproxy_endpoint -l $myproxy_user -p $myproxy_port -o ${personal_credential_repo}/certificate-file -T"
+    echo "myproxy-logon -s $myproxy_endpoint -l $myproxy_user -p $myproxy_port -o ${personal_credential_repo}/certificate-file -T"
     X509_CERT_DIR=${_X509_CERT_DIR} \
         X509_USER_KEY=${_X509_USER_KEY} \
         X509_USER_CERT=${_X509_USER_CERT} \
-        $globus_location/bin/myproxy-logon -s $myproxy_endpoint -l $myproxy_user -p $myproxy_port -o ${personal_credential_repo}/certificate-file -T
+        myproxy-logon -s $myproxy_endpoint -l $myproxy_user -p $myproxy_port -o ${personal_credential_repo}/certificate-file -T
     [ $? != 0 ] && echo " ERROR: MyProxy not setup properly.  Unable to execute command." && return 1
 
     chown -R ${installer_uid}:${installer_gid} ${personal_credential_repo}

--- a/globus/esg-globus
+++ b/globus/esg-globus
@@ -897,7 +897,7 @@ test_gridftp_server() {
     while [ -n "$1" ]; do
         case $1 in
             end-user)
-                echo "$globus_location/bin/myproxy-logon -s $myproxy_endpoint -l rootAdmin -p $myproxy_port -T"
+                echo "myproxy-logon -s $myproxy_endpoint -l rootAdmin -p $myproxy_port -T"
                 X509_CERT_DIR=${_X509_CERT_DIR} \
                     X509_USER_KEY=${_X509_USER_KEY} \
                     X509_USER_CERT=${_X509_USER_CERT} \

--- a/globus/esg-globus
+++ b/globus/esg-globus
@@ -649,6 +649,11 @@ post_gridftp_jail_setup() {
 
     if $(echo "${gridftp_chroot_jail}" | grep "${esg_root_dir}" >& /dev/null); then echo "*"; else (echo "illegal chroot location: ${gridftp_chroot_jail}" && return 1); fi
 
+    # Add a test data file if already not added
+    if [ ! -f ${gridftp_chroot_jail}/esg_dataroot/test/sftlf.nc ]; then
+        mkdir -p ${gridftp_chroot_jail}/esg_dataroot/test
+        echo test > ${gridftp_chroot_jail}/esg_dataroot/test/sftlf.nc
+    fi
 
     echo -n "writing sanitized passwd file to [${gridftp_chroot_jail}/etc/passwd]"
     if [ -e ${gridftp_chroot_jail}/etc/passwd ]; then
@@ -870,7 +875,7 @@ test_auth_service() {
     echo -n "Testing authorization service on ${esgf_host} ... "
     ! ${adq_client} https://${esgf_host}/esg-orp/saml/soap/secure/authorizationService.htm https://${esgf_host}/esgf-idp/openid/rootAdmin gsiftp://${esgf_host}:${gridftp_server_port}//esg_dataroot/test/sftlf.nc | grep -q 'NOT PERMIT' >& /dev/null
     local ret=$?
-    [ ${ret} == 0 ] && echo "[OK]" || echo "[FAIL]"
+    [ ${ret} == 0 ] && [OK] || [FAIL]
     return ${ret}
 }
 
@@ -896,24 +901,24 @@ test_gridftp_server() {
                 X509_CERT_DIR=${_X509_CERT_DIR} \
                     X509_USER_KEY=${_X509_USER_KEY} \
                     X509_USER_CERT=${_X509_USER_CERT} \
-                    $globus_location/bin/myproxy-logon -s $myproxy_endpoint -l rootAdmin -p $myproxy_port -T
+                    myproxy-logon -s $myproxy_endpoint -l rootAdmin -p $myproxy_port -T
                 [ $? != 0 ] && echo " ERROR: MyProxy not setup properly.  Unable to execute command." && return 1
 
-                echo -n "GridFTP - End-User Test... [$1]"
+                echo -n "GridFTP - End-User Test... [$1] "
                 tmpdestfile=$(mktemp)
                 X509_CERT_DIR=${_X509_CERT_DIR} \
                     X509_USER_KEY=${_X509_USER_KEY} \
                     X509_USER_CERT=${_X509_USER_CERT} \
-                    ${globus_location}/bin/globus-url-copy gsiftp://${esgf_host:-localhost}:${gridftp_server_port}/esg_dataroot/test/sftlf.nc ${tmpdestfile} && \
+                    globus-url-copy gsiftp://${esgf_host:-localhost}:${gridftp_server_port}/esg_dataroot/test/sftlf.nc ${tmpdestfile} && \
                     diff <(echo $(md5sum ${tmpdestfile} | awk '{print $1}')) <(echo $(md5sum /esg/gridftp_root/esg_dataroot/test/sftlf.nc | awk '{print $1}')) && \
-                    rm -f ${tmpdestfile} && echo "[OK]" || ( echo "[FAIL]" && ((ret++)) )
+                    rm -f ${tmpdestfile} && [OK] || ( [FAIL] && ((ret++)) )
                 ;;
             bdm)
-                echo -n "GridFTP - BDM Test... [$1]"
+                echo -n "GridFTP - BDM Test... [$1] "
                 tmpdestfile=$(mktemp)
-                ${globus_location}/bin/globus-url-copy gsiftp://${esgf_host:-localhost}:${gridftp_bdm_server_port}/esg_dataroot/test/sftlf.nc ${tmpdestfile} && \
+                globus-url-copy gsiftp://${esgf_host:-localhost}:${gridftp_bdm_server_port}/esg_dataroot/test/sftlf.nc ${tmpdestfile} && \
                     diff <(echo $(md5sum ${tmpdestfile} | awk '{print $1}')) <(echo $(md5sum /esg/gridftp_root/esg_dataroot/test/sftlf.nc | awk '{print $1}')) && \
-                    rm -f ${tmpdestfile} && echo "[OK]" || ( echo "[FAIL]" && ((ret++)) )
+                    rm -f ${tmpdestfile} && [OK] || ( [FAIL] && ((ret++)) )
                 ;;
             *)
                 [ -n "$1" ] && echo "unknown parameter [$1]"


### PR DESCRIPTION
The pull request includes changes in test functions required after moving from Globus tarball to Globus RPMs. It also add a test data file for a test GridFTP download.

Globus can be tested directly:
 esg-node --test-globus end-user
or as a part of publication test:
 esg-node --test-pub