### PR TITLE
Install PIL package for cog manually

### DIFF
--- a/cog/esg-cog
+++ b/cog/esg-cog
@@ -88,6 +88,12 @@ if [ $? != 0 ]; then
 fi
 git pull
 
+# FIXME: must download and install PIL manually                                                                         cd $COG_DIR
+wget http://effbot.org/media/downloads/PIL-1.1.7.tar.gz
+tar xfz PIL-1.1.7.tar.gz
+cd PIL-1.1.7
+python setup.py install
+
 # install CoG dependencies within Python virtual environment
 cd $COG_INSTALL_DIR
 python setup.py install


### PR DESCRIPTION
According to [PEP470](http://legacy.python.org/dev/peps/pep-0470/) and [this PYPI ticket](https://bitbucket.org/pypa/pypi/issues/365/many-packages-have-empty-list-of-links) projects that do not host their files at pypi.python.org are not available through the Simple API anymore. *esg_cog* fails to install correctly because of this missing dependency. A manual install fixes the installation process.