### PR TITLE
Install PIL package for cog manually

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -481,7 +481,7 @@ setup_postgress() {
     _is_managed_db && return 0
 
     echo -n "Checking for postgresql >= ${postgress_min_version} "
-    check_version ${postgress_bin_dir}/psql ${postgress_min_version}
+    check_version ${postgress_bin_dir}/postgres ${postgress_min_version}
     local ret=$?
     if [ $ret == 0 ] ; then
         (( ! force_install )) && [OK] && return 0

--- a/setup-autoinstall
+++ b/setup-autoinstall
@@ -175,6 +175,7 @@ if [ $numl -gt 1 ]; then
 		else
 			break;
 		fi
+	rm -f ips
 	done
 
 	if [ "$install_type" = "all" ]; then


### PR DESCRIPTION
According to [PEP470](http://legacy.python.org/dev/peps/pep-0470/) and [this PYPI ticket](https://bitbucket.org/pypa/pypi/issues/365/many-packages-have-empty-list-of-links) projects that do not host their files at pypi.python.org are not available through the Simple API anymore. esg_cog fails to install correctly because of this missing dependency. A manual install fixes the installation process.