### PR TITLE
Update Globus Connect Server if already installed

### DIFF
--- a/globus/esg-globus
+++ b/globus/esg-globus
@@ -349,10 +349,13 @@ install_globus() {
 
     # Install Globus and ESGF RPMs
     yum -y install ${config_type}
+    yum -y update ${config_type}
     if [ ${config_type} = 'globus-connect-server-io' ]; then
         yum -y install globus-authz-esgsaml-callout globus-gaa globus-adq customgsiauthzinterface
+        yum -y update globus-authz-esgsaml-callout globus-gaa globus-adq customgsiauthzinterface
     else
         yum -y install mhash pam-pgsql
+        yum -y update mhash pam-pgsql
     fi
 
     popd >& /dev/null


### PR DESCRIPTION
The globus-connect-server-*setup script checks if a new version of Globus Connect Server (GCS) is available, and if it is, the script prints a warning about it and exits what causes the installer failure. The esg-globus does not update installed GCS automatically what leads to the described installer failure. The fix updates installed GCS to avoid the situation.