### PR TITLE
do not update THREDDS web.xml if not a data node

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -6877,7 +6877,7 @@ main() {
     #---filters (TDS)--
 
 	# Getting TDS web.xml template file. Forcing download here let us update TDS filters config without going through tds_setup()
-        get_webxml_file
+        [ $((sel & DATA_BIT)) != 0 ] && get_webxml_file
 
         [ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & DATA_BIT)) != 0 ] && echo "security filters subsystem (SAML/ORP)"  && service_name="thredds" setup_subsystem security-tokenless-filters filters $@
         #[ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & DATA_BIT)) != 0 ] && echo "security filters subsystem (TOKEN)" && service_name="thredds" setup_subsystem security-token-filters filters $@


### PR DESCRIPTION
Fix a line that is breaking "--update" with an index-only node. Even if for the call to get_webxml_file there is no condition on $((sel & INSTALL_BIT)), it should still be conditional on the data component having been selected. If not a data node, it can do nothing useful, and in fact breaks the script because it tries to download the web.xml file to a non-existent local directory.