### PR TITLE
_is_in_git() will not return true for nonexistent targets

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -5034,6 +5034,11 @@ _is_in_git() {
     REALDIR=$(dirname $(_readlinkf ${1}))
     GITEXEC=`which git`
 
+    if [ ! -e $1 ] ; then
+        debug_print "DEBUG: ${1} does not exist yet, allowing creation"
+        return 1
+    fi
+
     if [ -d "${REALDIR}/.git" ] ; then
         debug_print "DEBUG: ${1} is in a git repository"
         return 0


### PR DESCRIPTION
This function exists to prevent esg-node from clobbering files
symlinked into git repositories because they're under active
development, but there isn't any point in preventing creation of files
that do not yet exist.