### PR TITLE
change auth service endpoint used by gridftp

### DIFF
--- a/globus/esg-globus
+++ b/globus/esg-globus
@@ -635,12 +635,18 @@ config_gridftp_server() {
 #By making this a separate function it may be called directly in the
 #event that the gateway_service_root needs to be repointed. (another Estani gem :-))
 write_esgsaml_auth_conf() {
-    echo "AUTHSERVICE=https://${myproxy_endpoint:-${esgf_idp_peer}}/esg-orp/saml/soap/secure/authorizationService.htm" > /etc/grid-security/esgsaml_auth.conf
-    echo 
-    echo "---------esgsaml_auth.conf---------"
-    cat /etc/grid-security/esgsaml_auth.conf
-    echo "---------------------------------"
-    echo     
+    local auth_conf=/etc/grid-security/esgsaml_auth.conf
+    if [ ! -e $auth_conf ]
+    then
+        local auth_url=`awk -F= '/orp.security.authorization.service.endpoint/ {print $2}' /esg/config/esgf.properties`
+        echo "AUTHSERVICE=$auth_url" > $auth_conf
+        echo "----(created) esgsaml_auth.conf----"
+    else
+        echo "---(existing) esgsaml_auth.conf----"
+    fi
+    cat $auth_conf
+    echo "-----------------------------------"
+    echo
     return 0
 }
 


### PR DESCRIPTION
Change the auth service endpoint for globus to point to orp.security.authorization.service.endpoint from esgf.properties (as used in the security filter for THREDDS), although do not overwrite any existing config.

@ncaripsl: I will raise this on the esgf_iwt list so hopefully discussion there will inform whether to merge this.