### PR TITLE
Fix the GridFTP log parser. Stop deleting CA certificates.

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -3087,17 +3087,13 @@ fetch_esgf_certificates() {
     echo "Fetching Freshest ESG Federation Certificates..."
     #_relocate_n_relink_globus_certicates_conf
     globus_global_certs_dir=/etc/grid-security/certificates
-    [ -d ${globus_global_certs_dir} ] && tar czf ${globus_global_certs_dir%/*}/${globus_global_certs_dir##*/}.bak.tgz ${globus_global_certs_dir} >& /dev/null && rm ${globus_global_certs_dir}/*
-    mkdir -p ${globus_global_certs_dir}
+    [ ! -d ${globus_global_certs_dir} ] mkdir -p ${globus_global_certs_dir}
     [ $? != 0 ] && echo "Could not create directory: [${globus_global_certs_dir}] :-(" && return 1
     local esg_trusted_certs_file=esg_trusted_certificates.tar
     debug_print "curl -s -L --insecure ${esg_dist_url_root}/certs/${esg_trusted_certs_file} | (cd ${globus_global_certs_dir}; pax -r -s ',.*/,,p')"
     curl -s -L --insecure ${esg_dist_url_root}/certs/${esg_trusted_certs_file} | (cd ${globus_global_certs_dir}; pax -r -s ',.*/,,p')
     local ret=$?
     rmdir ${globus_global_certs_dir}/$(echo ${esg_trusted_certs_file} | awk 'gsub(/('$compress_extensions')/,"")')
-    if [ $ret == 0 ]; then
-        [ -e ${globus_global_certs_dir%/*}/${globus_global_certs_dir##*/}.bak.tgz ] && rm ${globus_global_certs_dir%/*}/${globus_global_certs_dir##*/}.bak.tgz
-    fi
 
     local simpleCA_cert=$(readlink -f $(grep certificate_issuer_cert "${esg_root_dir}/config/myproxy/myproxy-server.config" 2> /dev/null | awk '{print $2}' | tr -d '\"') 2> /dev/null)
     if [ -n "${simpleCA_cert}" ]; then

--- a/globus/esg-globus
+++ b/globus/esg-globus
@@ -428,13 +428,13 @@ DBPORT=${postgress_port}
 DBUSER=${postgress_user}
 DBPASS=${pg_sys_acct_passwd}
 USAGEFILE=${gridftp_server_usage_log}
-TMPFILE=/tmp/__up_tmpfile
+TMPFILE=${esg_log_dir}/__up_tmpfile
 DEBUG=0
 NODBWRITE=0\n" > ${gridftp_server_usage_config}
 
     echo 'Setting up a cron job, /etc/cron.d/esg_usage_parser ...'
     local cronscript=${gridftp_server_usage_config%.*}.cron
-    echo "5 0,12 * * * ESG_USAGE_PARSER_CONF=${gridftp_server_usage_config} ${esg_tools_dir}/esg_usage_parser" > /etc/cron.d/esg_usage_parser
+    echo "5 0,12 * * * root ESG_USAGE_PARSER_CONF=${gridftp_server_usage_config} ${esg_tools_dir}/esg_usage_parser" > /etc/cron.d/esg_usage_parser
 
     return 0
 }


### PR DESCRIPTION
The pull request includes two fixes:
1) stop deleting the /etc/grid-security/certificates directory with CA certificates (fixed in esg-node)
2) add a username, the GridFTP log parser is executed as from /etc/cron.d/esg_usage_parser (fixed in esg-globus)