### PR TITLE
Fixes to esg-gitstrap and esg-autoinstall

### DIFF
--- a/esg-autoinstall
+++ b/esg-autoinstall
@@ -268,7 +268,7 @@ expect {
     }
 
     # Victory conditions
-    "(esg_datanode: cleaning up etc...)" {
+    "Node installation is complete." {
         exit 0
     }
 }

--- a/esg-gitstrap
+++ b/esg-gitstrap
@@ -168,6 +168,17 @@ my %repoinfo = (
         'configlinks' => [],
         'installerlinks' => [],
     },
+    'config' => {
+        'url' => 'https://github.com/ESGF/config.git',
+        'branch' => {
+            'stable'     => 'master',
+            'devel'      => 'devel',
+            'experiment' => 'devel',
+        },
+        'binlinks'       => [],
+        'configlinks'    => [],
+        'installerlinks' => [],
+    },
     'esgf-dashboard' => {
         'url' => 'git://github.com/ESGF/esgf-dashboard.git',
         'branch' => {
@@ -273,7 +284,7 @@ if($opt{'all'}) {
     @repolist = keys %repoinfo;
 }
 else {
-    @repolist = ( 'esgf-installer' );
+    @repolist = ( 'esgf-installer', 'config' );
 }
 
 foreach my $repo (@repolist) {

--- a/esg-gitstrap
+++ b/esg-gitstrap
@@ -148,9 +148,15 @@ my %repoinfo = (
             'devel'      => 'devel',
             'experiment' => 'experiment',
         },
-        'binlinks' => [ "esg-functions",
+        # esg-installarg MUST NOT be included in this list -- the
+        # install script will break if it is a symlink, and it will be
+        # downloaded by the first esg-node --set-type command
+        'binlinks' => [ "esg-autoinstall",
+                        "esg-functions",
                         "esg-gitstrap",
+                        "esg-init",
                         "esg-node",
+                        "esg-purge.sh",
                         "filters/esg-access-logging-filter",
                         "filters/esg-security-las-ip-filter",
                         "filters/esg-security-tokenless-filters",

--- a/esg-gitstrap
+++ b/esg-gitstrap
@@ -73,19 +73,21 @@ use constant EXIT_EXTERNALFAIL => 2;
 #######################
 
 my %opt = (
-    'debug' => 0,
-    'prefix' => '/usr/local',
-    'bindir' => 'bin',
-    'configdir' => 'esgf/config_defaults',
+    'all'          => 0,
+    'debug'        => 0,
+    'prefix'       => '/usr/local',
+    'bindir'       => 'bin',
+    'configdir'    => 'esgf/config_defaults',
     'installerdir' => 'esgf/installer',
-    'srcdir' => 'src/esgf',
-    'branch' => 'devel',
+    'srcdir'       => 'src/esgf',
+    'branch'       => 'devel',
     'force-branch' => 0,
-    'os' => detect_os(),
+    'os'           => detect_os(),
    );
 
 GetOptions(
     \%opt,
+    'all',
     'debug|v',
     'prefix=s',
     'bindir=s',
@@ -164,7 +166,7 @@ my %repoinfo = (
                         "product-server/esg-product-server",
                       ],
         'configlinks' => [],
-        'installerlinks' => [ "esg-autoinstall-testnode", "esg-purge.sh"],
+        'installerlinks' => [],
     },
     'esgf-dashboard' => {
         'url' => 'git://github.com/ESGF/esgf-dashboard.git',
@@ -266,7 +268,15 @@ umask 022;
 
 install_packages();
 
-foreach my $repo (keys %repoinfo) {
+my @repolist;
+if($opt{'all'}) {
+    @repolist = keys %repoinfo;
+}
+else {
+    @repolist = ( 'esgf-installer' );
+}
+
+foreach my $repo (@repolist) {
     my $repobranch = $repoinfo{$repo}->{'branch'}->{$opt{'branch'}};
 
     debug_print("now handling ${repo}");

--- a/esg-gitstrap
+++ b/esg-gitstrap
@@ -153,7 +153,6 @@ my %repoinfo = (
                         "esg-node",
                         "filters/esg-access-logging-filter",
                         "filters/esg-security-las-ip-filter",
-                        "filters/esg-security-token-filters",
                         "filters/esg-security-tokenless-filters",
                         "globus/esg-globus",
                         "product-server/esg-product-server",

--- a/esg-node
+++ b/esg-node
@@ -6988,6 +6988,7 @@ main() {
 
 	echo Writing additional settings to db.  If these settings already exist, psql will report an error, but ok to disregard.
 	psql -U dbsuper -c "insert into esgf_security.permission values (1, 1, 1, 't'); insert into esgf_security.role values (6, 'user', 'User Data Access');" esgcet
+        echo "Node installation is complete."
     fi
 
     #exec 1>&3 3>&- 2>&4 4>&-


### PR DESCRIPTION
Most notably, this fixes the problem with esg-autoinstall not running the final psql command in esg-node due to the last output text occurring before the command is run, and makes esg-gitstrap by default produce an environment much closer to esg-bootstrap.
