### PR TITLE
add extra newline between certificates

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -3619,6 +3619,7 @@ install_keypair() {
 	    fi
 	    
 	    cat $cert >>/etc/certs/tmpchain
+	    echo >> /etc/certs/tmpchain
 	done
 	cp /etc/certs/tmpchain /etc/certs/cachain.pem
 


### PR DESCRIPTION
To allow for the possibility that certificates lack a newline at the end of the file (on the "END CERTIFICATE" line), add an extra newline after each one when concatenating into a bundle. In the event that a newline already exists, it will add a harmless blank line, but if it does not, then this will avoid an error in which the line gets joined to the "BEGIN CERTIFICATE" line of the next file.