### PR TITLE
Devel

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -5284,7 +5284,6 @@ show_svc_list() {
 run_startup_hooks() {
     echo_strong "Running startup hooks..."
 	setup_sensible_confs
-	update_apache_conf
     ( esgcet_startup_hook )
     ( tds_startup_hook )
     (source ${scripts_dir}/esg-orp >& /dev/null && orp_startup_hook)

--- a/globus/esg-globus
+++ b/globus/esg-globus
@@ -666,7 +666,7 @@ config_gridftp_server() {
 #By making this a separate function it may be called directly in the
 #event that the gateway_service_root needs to be repointed. (another Estani gem :-))
 write_esgsaml_auth_conf() {
-    echo "AUTHSERVICE=https://${myproxy_endpoint:-${esgf_idp_peer}}/esg-orp/saml/soap/secure/authorizationService.htm" > /etc/grid-security/esgsaml_auth.conf
+    echo "AUTHSERVICE=https://${myproxy_endpoint:-${esgf_host}}/esg-orp/saml/soap/secure/authorizationService.htm" > /etc/grid-security/esgsaml_auth.conf
     echo 
     echo "---------esgsaml_auth.conf---------"
     cat /etc/grid-security/esgsaml_auth.conf


### PR DESCRIPTION
The pull request:
1) removes update_apache_config() from run_startup_hooks(), so Apache configuration file is not regenerated/updated when ESGF services are restarted (per discussion on the IWT call on Apr 13, 2017),
2) changes a URL to the authorization service in /etc/grid-security/esgsaml_auth.conf from esgf_idp_peer to esgf_host. GridFTP server on data type nodes should call the authorization service on the local node instead of on an IdP node.
