### PR TITLE
Fix AUTHSERVICE endpoint URL on data nodes

### DIFF
--- a/globus/esg-globus
+++ b/globus/esg-globus
@@ -666,7 +666,8 @@ config_gridftp_server() {
 #By making this a separate function it may be called directly in the
 #event that the gateway_service_root needs to be repointed. (another Estani gem :-))
 write_esgsaml_auth_conf() {
-    echo "AUTHSERVICE=https://${myproxy_endpoint:-${esgf_host}}/esg-orp/saml/soap/secure/authorizationService.htm" > /etc/grid-security/esgsaml_auth.conf
+    get_property orp_security_authorization_service_endpoint
+    echo "AUTHSERVICE=${orp_security_authorization_service_endpoint}" > /etc/grid-security/esgsaml_auth.conf
     echo 
     echo "---------esgsaml_auth.conf---------"
     cat /etc/grid-security/esgsaml_auth.conf


### PR DESCRIPTION
The fix sets AUTHSERVICE to esgf property orp.security.authorization.service.endpoint instead of myproxy_endpoint or, if myproxy_endpoint is not set, to esgf_host.