### PR TITLE
(partially tested) changes which would allow esgf_dist_mirror to be p…

### DIFF
--- a/esg-bootstrap
+++ b/esg-bootstrap
@@ -9,8 +9,7 @@
 #uses: wget
 devel=${devel:-0}
 install_prefix=${prefix:-"/usr/local"}
-script_maj_version="2.0"
-esg_dist_url=http://distrib-coffee.ipsl.jussieu.fr/pub/esgf/dist$( ((devel == 1)) && echo "/devel" || echo "")
+script_maj_version="2.5"
 
 id_check() {
     id | grep root >& /dev/null
@@ -18,8 +17,11 @@ id_check() {
     return 0
 }
 
+get_esg_dist_url() {
+    esg_dist_url=${esgf_dist_mirror:-http://distrib-coffee.ipsl.jussieu.fr/pub/esgf/dist}$( ((devel == 1)) && echo "/devel" || echo "")
+}
+
 get_latest() {
-    esg_dist_url=http://distrib-coffee.ipsl.jussieu.fr/pub/esgf/dist$( ((devel == 1)) && echo "/devel" || echo "")
     script_install_dir=${install_prefix}/bin
     mkdir -p ${script_install_dir}
     #NOTE: boot script location is a RedHat/CentOS thing... to make this cross distro compatible clean this up.
@@ -206,7 +208,8 @@ done
 
 if id_check
 then
-    (( devel == 1 )) && echo "(Setup to pull from DEVELOPMENT tree...)" && esg_dist_url=http://distrib-coffee.ipsl.jussieu.fr/pub/esgf/dist$( ((devel == 1)) && echo "/devel" || echo "")
+    (( devel == 1 )) && echo "(Setup to pull from DEVELOPMENT tree...)"
+    get_esg_dist_url
     self_verify
     (( $? > 0 )) && printf "WARNING: $0 could not be verified!! \n(This file, $(readlink -f ${0}), may have been tampered with or there is a newer version posted at the distribution server.\nPlease re-fetch this script.)\n\n" && exit 1
     echo "checking for updates for the ESGF Node"

--- a/esg-functions
+++ b/esg-functions
@@ -1327,10 +1327,12 @@ set_aside_web_app_cleanup() {
 #ESGF Distribution Mirrors Utilities
 #------------------------------------------
 
-esgf_dist_mirror=""
-
 get_esgf_dist_mirror() {
 
+    if [ -z "$esgf_dist_mirror" ]; then
+	return
+    fi
+    
     esgf_dist_mirrors_list=("distrib-coffee.ipsl.jussieu.fr/pub/esgf" "dist.ceda.ac.uk/esgf" "aims1.llnl.gov/esgf" "esg-dn2.nsc.liu.se/esgf")
 
 	declare -A resarray

--- a/esg-functions
+++ b/esg-functions
@@ -1329,7 +1329,7 @@ set_aside_web_app_cleanup() {
 
 get_esgf_dist_mirror() {
 
-    if [ -z "$esgf_dist_mirror" ]; then
+    if [ ! -z "$esgf_dist_mirror" ]; then
 	return
     fi
     


### PR DESCRIPTION
These (relatively small) changes which would allow `esgf_dist_mirror` to be passed in as an environment variable, although some further testing is needed.  This allows the node manager to specify an arbitrary mirror URL in the bootstrap and installer scripts.  Use cases include:

- the desired mirror is not listed (for example a dated snapshot)
- the node manager wants to avoid polling all the mirror sites every time esg-node runs

Example usage (where `yyyymmdd` below is some future date after this change is tested and incorporated):
```
# point mirror at a dated snapshot
export esgf_dist_mirror=http://dist.ceda.ac.uk/esgf_snapshots/yyyymmdd/dist

# get bootstrap from specified mirror
wget $esgf_dist_mirror/devel/esgf-installer/2.5/esg-bootstrap

 # use bootstrap to download esg-node from specified mirror
chmod +x esg-bootstrap
./esg-bootstrap --devel

# main installation from specified mirror
esg-node --type index data idp --install
```

An email I am about to send to esg-iwt list discusses this further.

The current version of the esg-bootstrap script appears to have script_maj_version hard-coded as 2.0.  This pull request changes it to 2.5, but the versioning details may need to be checked because it is not clear to me how the copies of the bootstrap script in the various version subdirectories (for example http://distrib-coffee.ipsl.jussieu.fr/pub/esgf/dist/esgf-installer/2.5/esg-bootstrap) are generated.