### PR TITLE
point cdat_home at a more appropriate location (the esgf-pub conda environment)

### DIFF
--- a/esg-init
+++ b/esg-init
@@ -97,7 +97,8 @@ init() {
     postgress_host=${PGHOST:-localhost}
     postgress_port=${PGPORT:-5432}
     #cmake_install_dir=${CMAKE_HOME:-${install_prefix}/cmake}
-    cdat_home=${CDAT_HOME:-${install_prefix}/conda}
+    conda_home=${install_prefix}/conda
+    cdat_home=${conda_home}/envs/esgf-pub
     java_opts=${JAVA_OPTS:-""}
     java_install_dir=${JAVA_HOME:-${install_prefix}/java}
     ant_install_dir=${ANT_HOME:-${install_prefix}/ant}
@@ -136,7 +137,7 @@ init() {
     export CATALINA_OPTS=${tomcat_opts}
     export GLOBUS_LOCATION=${globus_location}
 
-    myPATH=$OPENSSL_HOME/bin:$CMAKE_HOME/bin:$JAVA_HOME/bin:$ANT_HOME/bin:$CDAT_HOME/bin:$CDAT_HOME/Externals/bin:$CATALINA_HOME/bin:$GLOBUS_LOCATION/bin:${install_prefix}/bin:/bin:/sbin:/usr/bin:/usr/sbin
+    myPATH=$OPENSSL_HOME/bin:$CMAKE_HOME/bin:$JAVA_HOME/bin:$ANT_HOME/bin:$CDAT_HOME/bin:$CATALINA_HOME/bin:$GLOBUS_LOCATION/bin:${install_prefix}/bin:/bin:/sbin:/usr/bin:/usr/sbin
     myLD_LIBRARY_PATH=$OPENSSL_HOME/lib:$CDAT_HOME/Externals/lib:$GLOBUS_LOCATION/lib:${install_prefix}/geoip/lib:/usr/lib64:/usr/lib
     export PATH=$(_path_unique $myPATH:$PATH)
     export LD_LIBRARY_PATH=$(_path_unique $myLD_LIBRARY_PATH:$LD_LIBRARY_PATH)

--- a/esg-node
+++ b/esg-node
@@ -883,10 +883,10 @@ setup_cdat() {
        [ $? != 0 ] && printf "$([FAIL]) \n\tCould not fetch miniconda setup\n\n" && checked_done 1
     fi
 
-     bash Miniconda2-latest-Linux-x86_64.sh -b -p $cdat_home
+     bash Miniconda2-latest-Linux-x86_64.sh -b -p $conda_home
       [ $? != 0 ] && printf "$([FAIL]) \n\tError in executing Miniconda setup\n\n" && checked_done 1
 
-    export PATH=${cdat_home}/bin:$PATH
+    export PATH=${cdat_home}/bin:${conda_home}/bin:$PATH
 
     if [ $ESGF_INSECURE > 0 ] ; then
         conda config --set ssl_verify False
@@ -894,7 +894,7 @@ setup_cdat() {
     fi
 
     # create a default environment for the publisher with cduitl (and cdms2)
-    if [ ! -d ${cdat_home}/envs/esgf-pub ] ; then
+    if [ ! -d $cdat_home ] ; then
     unset LD_LIBRARY_PATH
 
 	conda create -y -n esgf-pub -c conda-forge -c uvcdat cdutil


### PR DESCRIPTION
The variable `cdat_home` is set in the installer to point to the root conda environment rather than the esgf-pub one.  This seems to be causing various problems.  The root conda environment is never activated in any of the scripts, so no software gets installed into it.  Only the esgf-pub conda environment is activated.

This pull request modifies the value of `cdat_home` to point to `/usr/local/conda/envs/esgf-pub` instead of `/usr/local/conda`.

`$cdat_home` is used in various places, of which it seems that the only places where it is needed to point to the root env are:

* where used in `esg-node` when first setting up miniconda -- which is modified accordingly in this pull request.

* a line in `clean_node_manager_database_subsystem_installation`, which I will modify in a separate pull request for that repo.

But I have looked through, and it seems that in all the other cases, it would be better pointing to the esgf-pub environment.  Here is a list of the other contexts where it is used inside `/usr/local/bin/esg*` (other than in "echo" statements).

1) `${cdat_home}/bin/python` 

used to test existence of CDAT installation and python version (in `esg-node` and `esg-functions`).

2) `$cdat_home/bin/easy_install`

used in `esg-security` for installation; this causes problems if set to the root env rather than the esg-pub one, see issue #273 for details

3) `source $cdat_home/bin/activate esgf-pub`

this will work equally whether the activate script is the one under root or under esgf-pub

4) `$cdat_home/bin/esgpublish` and `$cdat_home/bin/esgunpublish`

Used in `esg-node` in `test_tds()` and `test_publication()`. These will fail if it points to root env, so these tests are not working properly.

5) The following:
```
$cdat_home/bin/esgf_dashboard_initialize
$cdat_home/bin/esgf_node_manager_initialize
$cdat_home/bin/esgf_security_initialize
```
These are used in cleanup functions in each of the relevant scripts, and these will not work properly if pointing to the root env.

6) used to set `$CDAT_HOME` in `esg-node`

The only use of `CDAT_HOME` by the esgf scripts is to write it to `esg.env`, but from there it may possibly be used by CDAT. If so, it ought to point to where the installation is.

Some potential inconsistency between 
```
    cdat_home=${CDAT_HOME:-${install_prefix}/conda}
```
in `esg-init` and 
```
    CDAT_HOME=${cdat_home}
```
in `esg-node` will be removed by the change to `esg-init` in this pull request.

7) it is used to set `PATH` in `setup_cdat()` in `esg-node`:
```
    export PATH=${cdat_home}/bin:$PATH
```
this ought to be the esgf-pub bin directory, although this pull request also adds the one in the root env after it so that `conda` can be found during setup before the esgf-pub environment is created

----

I also note here that there are lines in various scripts to set it to `$install_prefix/cdat` if not already set:
```
cdat_home=${cdat_home:-${install_prefix}/cdat}
```
Probably this does nothing as the variable *is* already set when this line is executed, but anyway this path is out of date and should be changed to the same value as in this pull request, i.e.
```
cdat_home=${cdat_home:-${install_prefix}/conda/envs/esgf-pub}
```
or else these lines deleted entirely. I'm not sending a pull request because this is spread over multiple repositories, so **I suggest updating these manually**. Do `grep cdat_home= /usr/local/bin/esg*` to see a list.