### PR TITLE
Revert "point cdat_home at a more appropriate location (the esgf-pub conda environment)"

### DIFF
--- a/esg-init
+++ b/esg-init
@@ -97,8 +97,7 @@ init() {
     postgress_host=${PGHOST:-localhost}
     postgress_port=${PGPORT:-5432}
     #cmake_install_dir=${CMAKE_HOME:-${install_prefix}/cmake}
-    conda_home=${install_prefix}/conda
-    cdat_home=${conda_home}/envs/esgf-pub
+    cdat_home=${CDAT_HOME:-${install_prefix}/conda}
     java_opts=${JAVA_OPTS:-""}
     java_install_dir=${JAVA_HOME:-${install_prefix}/java}
     ant_install_dir=${ANT_HOME:-${install_prefix}/ant}
@@ -137,7 +136,7 @@ init() {
     export CATALINA_OPTS=${tomcat_opts}
     export GLOBUS_LOCATION=${globus_location}
 
-    myPATH=$OPENSSL_HOME/bin:$CMAKE_HOME/bin:$JAVA_HOME/bin:$ANT_HOME/bin:$CDAT_HOME/bin:$CATALINA_HOME/bin:$GLOBUS_LOCATION/bin:${install_prefix}/bin:/bin:/sbin:/usr/bin:/usr/sbin
+    myPATH=$OPENSSL_HOME/bin:$CMAKE_HOME/bin:$JAVA_HOME/bin:$ANT_HOME/bin:$CDAT_HOME/bin:$CDAT_HOME/Externals/bin:$CATALINA_HOME/bin:$GLOBUS_LOCATION/bin:${install_prefix}/bin:/bin:/sbin:/usr/bin:/usr/sbin
     myLD_LIBRARY_PATH=$OPENSSL_HOME/lib:$CDAT_HOME/Externals/lib:$GLOBUS_LOCATION/lib:${install_prefix}/geoip/lib:/usr/lib64:/usr/lib
     export PATH=$(_path_unique $myPATH:$PATH)
     export LD_LIBRARY_PATH=$(_path_unique $myLD_LIBRARY_PATH:$LD_LIBRARY_PATH)

--- a/esg-node
+++ b/esg-node
@@ -883,10 +883,10 @@ setup_cdat() {
        [ $? != 0 ] && printf "$([FAIL]) \n\tCould not fetch miniconda setup\n\n" && checked_done 1
     fi
 
-     bash Miniconda2-latest-Linux-x86_64.sh -b -p $conda_home
+     bash Miniconda2-latest-Linux-x86_64.sh -b -p $cdat_home
       [ $? != 0 ] && printf "$([FAIL]) \n\tError in executing Miniconda setup\n\n" && checked_done 1
 
-    export PATH=${cdat_home}/bin:${conda_home}/bin:$PATH
+    export PATH=${cdat_home}/bin:$PATH
 
     if [ $ESGF_INSECURE > 0 ] ; then
         conda config --set ssl_verify False
@@ -894,7 +894,7 @@ setup_cdat() {
     fi
 
     # create a default environment for the publisher with cduitl (and cdms2)
-    if [ ! -d $cdat_home ] ; then
+    if [ ! -d ${cdat_home}/envs/esgf-pub ] ; then
     unset LD_LIBRARY_PATH
 
 	conda create -y -n esgf-pub -c conda-forge -c uvcdat cdutil


### PR DESCRIPTION
Reverts ESGF/esgf-installer#275  I don't think we want to change $cdat_home - $conda_home would be a better name for it now, but that is too cumbersome.  Better to switch the rms to delete the right path.