### PR TITLE
Set up the ESGF Auth client to a data node

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -7157,6 +7157,7 @@ main() {
     #---------------------------------------
 
     #---subsystems-----
+        [ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & DATA_BIT)) != 0 ] && echo "auth subsystem" && setup_subsystem_new auth esg-auth $@
         [ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & DATA_BIT+INDEX_BIT)) != 0 ] && echo "orp security subsystem" && setup_subsystem orp esg-orp $@
         #[ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & DATA_BIT)) != 0 ] && echo "drslib subsystem"  && setup_subsystem drslib esgf-drslib $@
 


### PR DESCRIPTION
One line added to call the esg-auth script, https://github.com/ESGF/esgf-auth/blob/master/bin/esg-auth, that downloads and sets up the ESGF Auth Client (Django webapp), https://github.com/ESGF/esgf-auth.
The new authorization filter in TDS, esg.orp.app.AuthenticationRedirectFilter, redirects a user web browser to the ESGF Auth client when a user clicks an HTTP download link to download a dataset file. From the user perspective the ESGF Auth client acts the same way as ORP. It lets a user select an IdP and then the Auth client redirects the user to the selected IdP. The Auth client detects whether the IdP supports OAuth2 or OpenID only. OAuth2 is preferable authentication/authorization protocol between the Auth client and the IdP.