### PR TITLE
Esg setup cleanup

### DIFF
--- a/base/esg_setup.py
+++ b/base/esg_setup.py
@@ -55,21 +55,6 @@ def check_os():
     logger.debug("dist: %s", dist)
     return True
 
-def check_fqdn():
-    ''' Check the machine's fully qualified domain name'''
-
-    #NOTE This is a psuedo check.
-
-    err_msg = "Error getting fully qualified domain name"
-    try:
-        fqdn = socket.getfqdn()
-    except socket.error as err:
-        logger.error("%s, %s", err_msg, str(err))
-        raise
-    exit_on_false(fqdn != '' and fqdn != None, err_msg)
-
-    logger.debug("FQDN: %s", fqdn)
-    return True
 
 def check_prerequisites():
     '''
@@ -80,7 +65,6 @@ def check_prerequisites():
     print "Checking prerequisites..."
     check_os()
     check_if_root()
-    check_fqdn()
 
     return True
 

--- a/esgf_utilities/esg_cli_argument_manager.py
+++ b/esgf_utilities/esg_cli_argument_manager.py
@@ -13,7 +13,6 @@ from esgf_utilities import pybash
 from esgf_utilities import esg_property_manager
 from esgf_utilities import esg_version_manager
 from esgf_utilities import esg_cert_manager, esg_truststore_manager
-from base import esg_setup
 from base import esg_apache_manager
 from base import esg_tomcat_manager
 from base import esg_postgres
@@ -399,18 +398,15 @@ def process_arguments():
         sys.exit(0)
     elif args.start:
         logger.debug("args: %s", args)
-        esg_setup.check_prerequisites()
         node_type_list = esg_functions.get_node_type()
         logger.debug("START SERVICES: %s", node_type_list)
         return start(node_type_list)
     elif args.stop:
-        esg_setup.check_prerequisites()
         logger.debug("STOP SERVICES")
         node_type_list = esg_functions.get_node_type()
         stop(node_type_list)
         sys.exit(0)
     elif args.restart:
-        esg_setup.check_prerequisites()
         logger.debug("RESTARTING SERVICES")
         node_type_list = esg_functions.get_node_type()
         stop(node_type_list)

--- a/tests/test_esg_setup.py
+++ b/tests/test_esg_setup.py
@@ -27,8 +27,5 @@ class test_ESG_Setup(unittest.TestCase):
     def test_check_if_root(self):
         self.assertTrue(esg_setup.check_if_root())
 
-    def test_check_fqdn(self):
-        self.assertTrue(esg_setup.check_fqdn())
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Since check_prerequisites is invoked in the main function of esg_node, there is no need to make these checks again. Additionally, the FQDN is verified by the user in the questionnaire.

esg_setup is becoming smaller and smaller. Soon it may have its functionality relocated and be removed all together. 