### PR TITLE
Set default mail.admin.address to None

### DIFF
--- a/data_node/thredds.py
+++ b/data_node/thredds.py
@@ -251,10 +251,11 @@ def write_tds_env():
 
 def update_mail_admin_address():
     '''Updates mail_admin_address in threddsConfig.xml'''
-    mail_admin_address = esg_property_manager.get_property("mail.admin.address")
-    esg_functions.stream_subprocess_output('sed -i "s/support@my.group/{mail_admin_address}/g" /esg/content/thredds/threddsConfig.xml'.format(mail_admin_address=mail_admin_address))
-
-
+    try:
+        mail_admin_address = esg_property_manager.get_property("mail.admin.address")
+        esg_functions.stream_subprocess_output('sed -i "s/support@my.group/{mail_admin_address}/g" /esg/content/thredds/threddsConfig.xml'.format(mail_admin_address=mail_admin_address))
+    except ConfigParser.NoOptionError:
+        pass
 def esgsetup_thredds():
     '''Configures Thredds with esgsetup'''
     os.environ["UVCDAT_ANONYMOUS_LOG"] = "no"

--- a/data_node/thredds.py
+++ b/data_node/thredds.py
@@ -253,9 +253,11 @@ def update_mail_admin_address():
     '''Updates mail_admin_address in threddsConfig.xml'''
     try:
         mail_admin_address = esg_property_manager.get_property("mail.admin.address")
-        esg_functions.stream_subprocess_output('sed -i "s/support@my.group/{mail_admin_address}/g" /esg/content/thredds/threddsConfig.xml'.format(mail_admin_address=mail_admin_address))
     except ConfigParser.NoOptionError:
-        pass
+        return
+    else:
+        esg_functions.replace_string_in_file('/esg/content/thredds/threddsConfig.xml', "support@my.group", mail_admin_address)
+
 def esgsetup_thredds():
     '''Configures Thredds with esgsetup'''
     os.environ["UVCDAT_ANONYMOUS_LOG"] = "no"

--- a/esgf_utilities/esg_questionnaire.py
+++ b/esgf_utilities/esg_questionnaire.py
@@ -167,13 +167,10 @@ def _choose_mail_admin_address(force_install=False):
 
 def _choose_publisher_db_user(force_install=False):
     '''Sets the name of the database user for the Publisher'''
-    publisher_db_user = esg_property_manager.get_property("publisher.db.user")
-    if publisher_db_user and not force_install:
-        print "Found existing value for property publisher_db_user: {publisher_db_user}".format(publisher_db_user=publisher_db_user)
-        logger.info("publisher_db_user: %s", publisher_db_user)
+    try:
+        logger.info("publisher.db.user = [%s]", esg_property_manager.get_property("publisher.db.user"))
         return
-
-    else:
+    except ConfigParser.NoOptionError:
         default_publisher_db_user = "esgcet"
         publisher_db_user_input = raw_input(
             "What is the (low privilege) db account for publisher? [{default_publisher_db_user}]: ".format(default_publisher_db_user=default_publisher_db_user)) or default_publisher_db_user

--- a/esgf_utilities/esg_questionnaire.py
+++ b/esgf_utilities/esg_questionnaire.py
@@ -158,7 +158,7 @@ def _choose_mail_admin_address(force_install=False):
         return
     except ConfigParser.NoOptionError:
         mail_admin_address_input = raw_input(
-            "What email address should notifications be sent as? [{mail_admin_address}]: ".format(mail_admin_address=esg_property_manager.get_property("mail.admin.address")))
+            "What email address should notifications be sent as? [{mail_admin_address}]: ".format(mail_admin_address=None))
         if mail_admin_address_input:
             esg_property_manager.set_property(
                 "mail_admin_address", mail_admin_address_input)


### PR DESCRIPTION
This will conflict with None being an invalid value for this
property and will need to be fixed in the future. Additionally,
add a try/except check where the property is used. This was
originally made to solve #486 and #487 because they were 
thought to be similar, but #487 turned out to be a separate 
issue.