### PR TITLE
Write to env file using EnvWriter

### DIFF
--- a/base/esg_java.py
+++ b/base/esg_java.py
@@ -7,6 +7,7 @@ from esgf_utilities import esg_functions
 from esgf_utilities import esg_property_manager
 from esgf_utilities import esg_version_manager
 from esgf_utilities.esg_exceptions import SubprocessError
+from esgf_utilities.esg_env_manager import EnvWriter
 
 logger = logging.getLogger("esgf_logger" + "." + __name__)
 
@@ -56,13 +57,7 @@ def download_java(java_tarfile):
 
 def write_java_env():
     '''Writes Java config to /etc/esg.env'''
-    esg_property_manager.set_property(
-        "JAVA_HOME", "export JAVA_HOME={}".format(config["java_install_dir"]),
-        property_file=config["envfile"],
-        section_name="esgf.env",
-        separator="_"
-    )
-
+    EnvWriter.write("JAVA_HOME", config["java_install_dir"])
 
 def write_java_install_log():
     '''Writes Java config to install manifest'''
@@ -129,8 +124,7 @@ def setup_java():
 
 def write_ant_env():
     '''Writes Ant config to /etc/esg.env'''
-    esg_property_manager.set_property("ANT_HOME", "export ANT_HOME=/usr/bin/ant", property_file=config["envfile"], section_name="esgf.env", separator="_")
-
+    EnvWriter.write("ANT_HOME", "/usr/bin/ant")
 
 def write_ant_install_log():
     '''Writes Ant config to install manifest'''

--- a/base/esg_postgres.py
+++ b/base/esg_postgres.py
@@ -17,6 +17,7 @@ from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from esgf_utilities import esg_functions
 from esgf_utilities import esg_property_manager
 from esgf_utilities import pybash
+from esgf_utilities.esg_env_manager import EnvWriter
 
 logger = logging.getLogger("esgf_logger" + "." + __name__)
 
@@ -526,13 +527,13 @@ def log_postgres_properties():
 
 def write_postgress_env():
     '''Write postgres environment properties to /etc/esg.env'''
-    esg_property_manager.set_property("PGHOME", "export PGHOME=/usr/bin/postgres", property_file=config["envfile"], section_name="esgf.env", separator="_")
-    esg_property_manager.set_property("PGUSER", "export PGUSER={}".format(config["postgress_user"]), property_file=config["envfile"], section_name="esgf.env", separator="_")
-    esg_property_manager.set_property("PGPORT", "export PGPORT={}".format(config["postgress_port"]), property_file=config["envfile"], section_name="esgf.env", separator="_")
-    esg_property_manager.set_property("PGBINDIR", "export PGBINDIR={}".format(config["postgress_bin_dir"]), property_file=config["envfile"], section_name="esgf.env", separator="_")
-    esg_property_manager.set_property("PGLIBDIR", "export PGLIBDIR={}".format(config["postgress_lib_dir"]), property_file=config["envfile"], section_name="esgf.env", separator="_")
-    esg_property_manager.set_property("PATH", config["myPATH"], property_file=config["envfile"], section_name="esgf.env", separator="_")
-    esg_property_manager.set_property("LD_LIBRARY_PATH", config["myLD_LIBRARY_PATH"], property_file=config["envfile"], section_name="esgf.env", separator="_")
+    EnvWriter.write("PGHOME", "/usr/bin/postgres")
+    EnvWriter.write("PGUSER", config["postgress_user"])
+    EnvWriter.write("PGPORT", config["postgress_port"])
+    EnvWriter.write("PGBINDIR", config["postgress_bin_dir"])
+    EnvWriter.write("PGLIBDIR", config["postgress_lib_dir"])
+    EnvWriter.write("PATH", config["myPATH"])
+    EnvWriter.write("LD_LIBRARY_PATH", config["myLD_LIBRARY_PATH"],)
 
 def write_postgress_install_log():
     '''Write postgres version to install manifest'''

--- a/base/esg_tomcat_manager.py
+++ b/base/esg_tomcat_manager.py
@@ -21,6 +21,7 @@ from esgf_utilities import esg_functions
 from esgf_utilities import pybash
 from esgf_utilities import esg_property_manager, esg_keystore_manager, esg_truststore_manager
 from esgf_utilities import esg_cert_manager, CA
+from esgf_utilities.esg_env_manager import EnvWriter
 
 logger = logging.getLogger("esgf_logger" + "." + __name__)
 current_directory = os.path.join(os.path.dirname(__file__))
@@ -379,7 +380,7 @@ def edit_server_xml():
 
 def write_tomcat_env():
     '''Write tomcat environment info to /etc/esg.env'''
-    esg_property_manager.set_property("CATALINA_HOME", "export CATALINA_HOME={}".format(config["tomcat_install_dir"]), property_file=config["envfile"], section_name="esgf.env", separator="_")
+    EnvWriter.write("CATALINA_HOME", config["tomcat_install_dir"])
     esg_property_manager.set_property("PATH_with_tomcat", os.environ["PATH"]+":/usr/local/tomcat/bin")
 
 def write_tomcat_install_log():

--- a/data_node/esg_publisher.py
+++ b/data_node/esg_publisher.py
@@ -16,6 +16,7 @@ from esgf_utilities import esg_functions
 from esgf_utilities import esg_property_manager
 from esgf_utilities import pybash
 from esgf_utilities.esg_exceptions import SubprocessError
+from esgf_utilities.esg_env_manager import EnvWriter
 
 
 logger = logging.getLogger("esgf_logger" +"."+ __name__)
@@ -186,7 +187,7 @@ def setup_publisher():
 
 def write_esgcet_env():
     '''Write Publisher environment properties to /etc/esg.env'''
-    esg_property_manager.set_property("ESG_ROOT_ID", "export ESG_ROOT_ID={}".format(esg_property_manager.get_property("esg.org.name")), property_file=config["envfile"], section_name="esgf.env", separator="_")
+    EnvWriter.write("ESG_ROOT_ID", esg_property_manager.get_property("esg.org.name"))
 
     # env needed by Python client to trust the data node server certicate
     # ENV SSL_CERT_DIR /etc/grid-security/certificates

--- a/data_node/thredds.py
+++ b/data_node/thredds.py
@@ -17,6 +17,7 @@ from esgf_utilities import esg_property_manager
 from esgf_utilities import esg_truststore_manager
 from esgf_utilities.esg_exceptions import SubprocessError
 from base import esg_tomcat_manager, esg_postgres
+from esgf_utilities.esg_env_manager import EnvWriter
 
 
 logger = logging.getLogger("esgf_logger" +"."+ __name__)
@@ -246,8 +247,8 @@ def select_idp_peer():
 
 def write_tds_env():
     '''Write thredds info to /etc/esg.env'''
-    esg_property_manager.set_property("ESGF_IDP_PEER_NAME", "export ESGF_IDP_PEER_NAME={}".format(esg_property_manager.get_property("esgf_idp_peer_name")), property_file=config["envfile"], section_name="esgf.env", separator="_")
-    esg_property_manager.set_property("ESGF_IDP_PEER", "export ESGF_IDP_PEER={}".format(esg_property_manager.get_property("esgf_idp_peer")), property_file=config["envfile"], section_name="esgf.env", separator="_")
+    EnvWriter.write("ESGF_IDP_PEER_NAME", esg_property_manager.get_property("esgf_idp_peer_name"))
+    EnvWriter.write("ESGF_IDP_PEER", esg_property_manager.get_property("esgf_idp_peer"))
 
 def update_mail_admin_address():
     '''Updates mail_admin_address in threddsConfig.xml'''

--- a/esg_node.py
+++ b/esg_node.py
@@ -26,6 +26,7 @@ from esgf_utilities import esg_property_manager
 from esgf_utilities import esg_questionnaire
 from esgf_utilities import esg_cert_manager
 from filters import access_logging_filters, esg_security_tokenless_filters
+from esgf_utilities.esg_env_manager import EnvWriter
 
 
 logger = logging.getLogger("esgf_logger" +"."+ __name__)
@@ -142,12 +143,11 @@ def show_summary():
     print "-------------------"
 
     print "The following environment variables were used during last full install"
-    print "They are written to the file {}".format(config["envfile"])
+    print "They are written to the file {}".format(EnvWriter.envfile)
     print "Please source this file when using these tools"
 
     try:
-        with open(config["envfile"], 'r') as env_file:
-            print env_file.read()
+        EnvWriter.read()
     except IOError, error:
         logger.exception(error)
 
@@ -420,8 +420,7 @@ def system_launch(esg_dist_url, node_type_list, script_version, script_release):
 
     esg_property_manager.set_property("version", script_version)
     esg_property_manager.set_property("release", script_release)
-
-    esg_property_manager.set_property("activate_conda", "source /usr/local/conda/bin/activate esgf-pub", property_file=config["envfile"], section_name="esgf.env", separator="_")
+    EnvWriter.add_source("/usr/local/conda/bin/activate esgf-pub")
     #     write_as_property gridftp_config
     esg_node_finally(node_type_list)
 

--- a/esgf_utilities/esg_env_manager.py
+++ b/esgf_utilities/esg_env_manager.py
@@ -19,4 +19,4 @@ class _EnvWriter(object):
         with open(self.envfile, "r") as envfile:
             print envfile.read()
 
-EnvWriter = _EnvWriter("sample.env")
+EnvWriter = _EnvWriter("/etc/esg.env")

--- a/esgf_utilities/esg_env_manager.py
+++ b/esgf_utilities/esg_env_manager.py
@@ -1,0 +1,22 @@
+class _EnvWriter(object):
+    def __init__(self, envfile):
+        self.env = {}
+        self.envfile = envfile
+
+    def add_source(self, source_env):
+        with open(self.envfile, "w") as envfile:
+            for key in self.env:
+                envfile.write("export {}={}\n".format(key, self.env[key]))
+            envfile.write("source {}".format(source_env))
+
+    def write(self, variable, value):
+        self.env[variable] = value
+        with open(self.envfile, "w") as envfile:
+            for key in self.env:
+                envfile.write("export {}={}\n".format(key, self.env[key]))
+
+    def read(self):
+        with open(self.envfile, "r") as envfile:
+            print envfile.read()
+
+EnvWriter = _EnvWriter("sample.env")

--- a/idp_node/globus.py
+++ b/idp_node/globus.py
@@ -17,6 +17,7 @@ from base import esg_tomcat_manager
 from base import esg_postgres
 from idp_node import gridftp
 from idp_node import myproxy
+from esgf_utilities.esg_env_manager import EnvWriter
 
 
 logger = logging.getLogger("esgf_logger" +"."+ __name__)
@@ -86,8 +87,7 @@ def setup_globus(installation_type):
 
 def write_globus_env(globus_location):
     '''Write globus properties to /etc/esg.env'''
-    esg_property_manager.set_property("GLOBUS_LOCATION", "export GLOBUS_LOCATION={}".format(globus_location), property_file=config["envfile"], section_name="esgf.env", separator="_")
-
+    EnvWriter.write("GLOBUS_LOCATION", globus_location)
 
 def start_globus(installation_type):
     '''Starts the globus services by delegating out to esg-globus script

--- a/idp_node/myproxy.py
+++ b/idp_node/myproxy.py
@@ -16,6 +16,7 @@ from esgf_utilities import esg_cert_manager
 from esgf_utilities.esg_exceptions import SubprocessError
 from base import esg_tomcat_manager
 from base import esg_postgres
+from esgf_utilities.esg_env_manager import EnvWriter
 
 logger = logging.getLogger("esgf_logger" +"."+ __name__)
 current_directory = os.path.join(os.path.dirname(__file__))
@@ -426,5 +427,4 @@ def edit_etc_myproxyd():
         myproxy_esgf_file.write('''export MYPROXY_OPTIONS=\"-c {}/myproxy/myproxy-server.config -s /var/lib/globus-connect-server/myproxy-ca/store\"'''.format(config["esg_config_dir"]))
 
 def write_db_name_env():
-    esgf_db_name = esg_property_manager.get_property("db.database")
-    esg_property_manager.set_property("ESGF_DB_NAME", "export ESGF_DB_NAME={}".format(esgf_db_name), property_file=config["envfile"], section_name="esgf.env", separator="_")
+    EnvWriter.write("ESGF_DB_NAME", esg_property_manager.get_property("db.database"))


### PR DESCRIPTION
Double purposing the property_manager to write the env file is
problematic for development of the property_manager. A purposed
tool makes it much clearer what is happening and easy to maintain.

The functionality has been tested through an interactive Python session in
the installer environment on an installer test VM. A live test needs to be run.