### PR TITLE
Clean the postgres password upon retrival

### DIFF
--- a/esgf_utilities/esg_functions.py
+++ b/esgf_utilities/esg_functions.py
@@ -558,7 +558,7 @@ def get_postgres_password():
     pg_password = None
     try:
         with open(config['pg_secret_file'], "r") as secret_file:
-            pg_password = secret_file.read()
+            pg_password = secret_file.read().strip()
     except IOError:
         logger.exception("Could not open %s", config['pg_secret_file'])
 


### PR DESCRIPTION
This is to likely resolve #494 by removing excess spaces/newlines from the string read from the file.