### PR TITLE
Add log4j.jar installation

### DIFF
--- a/filters/esg_security_tokenless_filters.py
+++ b/filters/esg_security_tokenless_filters.py
@@ -140,6 +140,7 @@ def initialize_orp_jar_list():
     joda_version = "2.0"
     commons_io_version = "2.4"
     slf4j_version = "1.6.4"
+    log4j_version = "1.2.17"
 
     #----------------------------
     #Jar Libraries Needed To Be Present For ORP (tokenless) Filter Support
@@ -160,10 +161,12 @@ def initialize_orp_jar_list():
     joda_time_jar = "joda-time-{}.jar".format(joda_version)
     commons_io_jar = "commons-io-{}.jar".format(commons_io_version)
     slf4j_api_jar = "slf4j-api-{}.jar".format(slf4j_version)
+    # NOTE Since this is log4j12 the log4j version likely needs to be 1.2.*
     slf4j_log4j_jar = "slf4j-log4j12-{}.jar".format(slf4j_version)
+    log4j_jar = "log4j-{}.jar".format(log4j_version)
 
     return [opensaml_jar, openws_jar, xmltooling_jar, xsgroup_role_jar, commons_collections_jar, serializer_jar, velocity_jar,
-                xalan_jar, xercesImpl_jar, xml_apis_jar, xmlsec_jar, joda_time_jar, commons_io_jar, slf4j_api_jar, slf4j_log4j_jar]
+                xalan_jar, xercesImpl_jar, xml_apis_jar, xmlsec_jar, joda_time_jar, commons_io_jar, slf4j_api_jar, slf4j_log4j_jar, log4j_jar]
 
 def initialize_esgf_mirror_jar_list():
     #TODO: split spring/las jars into separate function


### PR DESCRIPTION
This system for installing these jar files seems highly unstable.
Should it not be as simple as pull all the needed .jar files from
the distribution mirro and copy them into their respective
locations? Why are they going into orp and then later being copied
to thredds? Also, the names of the files are hardcoded? What if the
version in the mirror changes or a jar is no longer needed? Unless
I am missing something this could use a significant overhaul.