### PR TITLE
Remove the installation of cdf2cim in bootstrapper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ netifaces == 0.10.6
 tld
 clint
 pyjks
-cdf2cim>=0.1.9.0
 colorlog


### PR DESCRIPTION
cdf2cim is listed as a requirement in setup.py of esgcet (the
publisher) and will be installed there. This will resolve the
version conflict issue that has been encountered. This is
to resolve #507 