### PR TITLE
Pip install

### DIFF
--- a/base/esg_apache_manager.py
+++ b/base/esg_apache_manager.py
@@ -6,7 +6,6 @@ import datetime
 import ConfigParser
 from distutils.spawn import find_executable
 import yaml
-import pip
 from esgf_utilities import esg_property_manager
 from esgf_utilities import pybash
 from esgf_utilities import esg_functions
@@ -73,12 +72,10 @@ def install_mod_wsgi():
     print "Setting mod_wsgi"
     print "******************************* \n"
 
-    try:
-        pip._internal.main(['install', "mod_wsgi==4.5.3"])
-    except AttributeError:
-        pip.main(['install', "mod_wsgi==4.5.3"])
+    esg_functions.pip_install("mod_wsgi==4.5.3")
     with pybash.pushd("/etc/httpd/modules"):
         # If installer running in a conda env
+        # TODO Make this more resilient to potential changes
         if "conda" in find_executable("python"):
             pybash.symlink_force(
                 "/usr/local/conda/envs/esgf-pub/lib/python2.7/site-packages/mod_wsgi/server/mod_wsgi-py27.so", "/etc/httpd/modules/mod_wsgi-py27.so")

--- a/data_node/esg_publisher.py
+++ b/data_node/esg_publisher.py
@@ -3,14 +3,9 @@
 '''
 import os
 import datetime
-import re
 import logging
 import ConfigParser
 import yaml
-try:
-    from pip._internal.operations import freeze
-except ImportError:
-    from pip.operations import freeze
 from esgf_utilities import esg_functions
 from esgf_utilities import esg_property_manager
 from esgf_utilities import pybash
@@ -24,15 +19,7 @@ with open(os.path.join(os.path.dirname(__file__), os.pardir, 'esg_config.yaml'),
 
 def check_publisher_version():
     '''Check if an existing version of the Publisher is found on the system'''
-    module_list = list(freeze.freeze())
-    matcher = re.compile("esgcet==.*")
-    results_list = filter(matcher.match, module_list)
-    if results_list:
-        version = results_list[0].split("==")[1]
-        print "Found existing esg-publisher installation (esg-publisher version {version})".format(version=version)
-        return version
-    else:
-        print "esg-publisher not found on system."
+    return esg_functions.pip_version("esgcet")
 
 def symlink_pg_binary():
     '''Creates a symlink to the /usr/bin directory so that the publisher setup.py script can find the postgres version'''
@@ -143,7 +130,7 @@ def run_esginitialize():
             print esginitialize_process["stdout"]
             print esginitialize_process["stderr"]
 
-def setup_publisher():
+def setup_publisher(tag=config["publisher_tag"]):
     '''Install ESGF publisher'''
 
     print "\n*******************************"
@@ -152,11 +139,9 @@ def setup_publisher():
 
     subdir = "src/python/esgcet"
     pkg_name = "esgcet"
-    tag = config["publisher_tag"]
-    base = "https://github.com/ESGF/esg-publisher.git"
-    pip_git = "git+{}@{}#egg={}&subdirectory={}".format(base, tag, pkg_name, subdir)
+    repo = "https://github.com/ESGF/esg-publisher.git"
     symlink_pg_binary()
-    esg_functions.call_binary("pip", ["install", pip_git])
+    esg_functions.pip_install_git(repo, pkg_name, tag, subdir)
     pybash.mkdir_p("/esg/data/test")
 
 

--- a/esg_bootstrap.sh
+++ b/esg_bootstrap.sh
@@ -58,7 +58,7 @@ install_dependencies_pip(){
   echo
   # activate virtual env and fetch some pre-requisites
   source ${CDAT_HOME}/bin/activate esgf-pub && \
-      conda install -y -c conda-forge lxml requests psycopg2 decorator Tempita myproxyclient \
+      conda install -y -c conda-forge lxml requests psycopg2 decorator Tempita \
       GitPython coloredlogs pip progressbar2 pyOpenSSL pylint \
       setuptools semver Pyyaml configobj psutil
 

--- a/esg_bootstrap.sh
+++ b/esg_bootstrap.sh
@@ -59,7 +59,7 @@ install_dependencies_pip(){
   # activate virtual env and fetch some pre-requisites
   source ${CDAT_HOME}/bin/activate esgf-pub && \
       conda install -y -c conda-forge lxml requests psycopg2 decorator Tempita myproxyclient \
-      SQLAlchemy sqlalchemy-migrate GitPython coloredlogs pip progressbar2 pyOpenSSL pylint \
+      GitPython coloredlogs pip progressbar2 pyOpenSSL pylint \
       setuptools semver Pyyaml configobj psutil
 
   # install other python pre-requisites

--- a/esg_node.py
+++ b/esg_node.py
@@ -10,7 +10,6 @@ import errno
 import filecmp
 import ConfigParser
 import yaml
-import pip
 from esgf_utilities import esg_functions
 from esgf_utilities import pybash
 from base import esg_setup
@@ -177,10 +176,6 @@ def system_component_installation(esg_dist_url, node_type_list):
         print "\n*******************************"
         print "Installing Data Node Components"
         print "******************************* \n"
-        try:
-            pip._internal.main(['install', "esgprep=={}".format(config["esgprep_version"])])
-        except AttributeError:
-            pip.main(['install', "esgprep=={}".format(config["esgprep_version"])])
         esg_publisher.main()
         from data_node import orp, thredds
         from idp_node import globus

--- a/esgf_utilities/esg_functions.py
+++ b/esgf_utilities/esg_functions.py
@@ -952,10 +952,14 @@ def call_binary(binary_name, arguments):
         #return stdout
         return output[1]
 
-def pip_install(pkg):
+def pip_install(pkg, req_file=False):
     ''' pip installs a package to the current python environment '''
     # TODO: Fine tune options such as --log, --retries and --timeout
-    return call_binary("pip", ["install", pkg])
+    args = ["install"]
+    if req_file:
+        args.append("-r")
+    args.append(pkg)
+    return call_binary("pip", args)
 
 def pip_install_git(repo, name, tag=None, subdir=None):
     ''' Builds a properly formatted string to pip install from a git repo '''

--- a/esgf_utilities/esg_functions.py
+++ b/esgf_utilities/esg_functions.py
@@ -14,6 +14,7 @@ import hashlib
 import shlex
 import socket
 import errno
+import json
 import pwd
 import grp
 import stat
@@ -951,7 +952,33 @@ def call_binary(binary_name, arguments):
         #return stdout
         return output[1]
 
+def pip_install(pkg):
+    ''' pip installs a package to the current python environment '''
+    # TODO: Fine tune options such as --log, --retries and --timeout
+    return call_binary("pip", ["install", pkg])
 
+def pip_install_git(repo, name, tag=None, subdir=None):
+    ''' Builds a properly formatted string to pip install from a git repo '''
+    git_pkg = "git+{repo}{tag}#egg={name}{subdir}".format(
+        repo=repo,
+        name=name,
+        tag="@"+tag if tag is not None else "",
+        subdir="&subdirectory="+subdir if subdir is not None else ""
+    )
+    return pip_install(git_pkg)
+
+def pip_version(pkg_name):
+    ''' Get the version of a package installed with pip, return None if not installed '''
+    info = call_binary("pip", ["list", "--format=json"])
+    info = json.loads(info)
+    # Get the dictionary with "name" matching pkg_name, if not present get None
+    pkg = next((pkg for pkg in info if pkg["name"] == pkg_name), None)
+    if pkg is None:
+        print "{} not found in pip list".format(pkg_name)
+        return None
+    else:
+        print "Found version {} of {} in pip list".format(str(pkg['version']), pkg_name)
+        return str(pkg['version'])
 
 def main():
     '''Main function'''

--- a/esgf_utilities/esg_functions.py
+++ b/esgf_utilities/esg_functions.py
@@ -964,7 +964,7 @@ def pip_install(pkg, req_file=False):
 def pip_install_git(repo, name, tag=None, subdir=None):
     ''' Builds a properly formatted string to pip install from a git repo '''
     git_pkg = "git+{repo}{tag}#egg={name}{subdir}".format(
-        repo=repo,
+        repo=repo if repo.endswith(".git") else repo+".git",
         name=name,
         tag="@"+tag if tag is not None else "",
         subdir="&subdirectory="+subdir if subdir is not None else ""

--- a/index_node/esg_cog.py
+++ b/index_node/esg_cog.py
@@ -91,7 +91,7 @@ def setup_cog(COG_DIR="/usr/local/cog"):
     # install CoG dependencies
     with pybash.pushd(COG_INSTALL_DIR):
         # "pip install -r requirements.txt"
-        esg_functions.pip_install("-r requirements.txt")
+        esg_functions.pip_install("requirements.txt", req_file=True)
 
         # setup CoG database and configuration
         esg_functions.stream_subprocess_output("python setup.py install")

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -9,7 +9,6 @@ class test_Pip(unittest.TestCase):
         repo = "https://github.com/bast/somepackage.git"
         version = "1.2.3"
 
-        esg_functions.call_binary("pip", ["uninstall", pkg])
         cur_version = esg_functions.pip_version(pkg)
         self.assertTrue(cur_version is None)
 
@@ -17,7 +16,7 @@ class test_Pip(unittest.TestCase):
         cur_version = esg_functions.pip_version(pkg)
         self.assertTrue(cur_version == version)
 
-        esg_functions.call_binary("pip", ["uninstall", pkg])
+        esg_functions.call_binary("pip", ["uninstall", "-y", pkg])
         cur_version = esg_functions.pip_version(pkg)
         self.assertTrue(cur_version is None)
 
@@ -25,7 +24,7 @@ class test_Pip(unittest.TestCase):
         cur_version = esg_functions.pip_version(pkg)
         self.assertTrue(cur_version == version)
 
-        esg_functions.call_binary("pip", ["uninstall", pkg])
+        esg_functions.call_binary("pip", ["uninstall", "-y", pkg])
         cur_version = esg_functions.pip_version(pkg)
         self.assertTrue(cur_version is None)
 

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -1,0 +1,33 @@
+import unittest
+from context import esgf_utilities
+from esgf_utilities import esg_functions
+
+class test_Pip(unittest.TestCase):
+
+    def test_pip(self):
+        pkg = "somepackage"
+        repo = "https://github.com/bast/somepackage.git"
+        version = "1.2.3"
+
+        esg_functions.call_binary("pip", ["uninstall", pkg])
+        cur_version = esg_functions.pip_version(pkg)
+        self.assertTrue(cur_version is None)
+
+        esg_functions.pip_install(pkg+"=="+version)
+        cur_version = esg_functions.pip_version(pkg)
+        self.assertTrue(cur_version == version)
+
+        esg_functions.call_binary("pip", ["uninstall", pkg])
+        cur_version = esg_functions.pip_version(pkg)
+        self.assertTrue(cur_version is None)
+
+        esg_functions.pip_install_git(repo, pkg)
+        cur_version = esg_functions.pip_version(pkg)
+        self.assertTrue(cur_version == version)
+
+        esg_functions.call_binary("pip", ["uninstall", pkg])
+        cur_version = esg_functions.pip_version(pkg)
+        self.assertTrue(cur_version is None)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
With the use of plumbum it is easier to use the pip executable to make installations. This is especially true as pip does not officially support being imported and used in that way for installations. This is related to #512 and #510 .