### PR TITLE
Use esgf-config repo to retreive missing static.xml files

### DIFF
--- a/esg_init.py
+++ b/esg_init.py
@@ -11,6 +11,8 @@ logger = logging.getLogger("esgf_logger" +"."+ __name__)
 
 def init():
     """ Return a list of all local variables."""
+    # TODO make this esgf-test or esgf-prod as specified
+    esgf_config_repo = "https://raw.githubusercontent.com/ESGF/esgf-config/master/esgf-test"
     #--------------
     # User Defined / Settable (public)
     #--------------

--- a/idp_node/idp.py
+++ b/idp_node/idp.py
@@ -88,6 +88,16 @@ def setup_idp():
         tomcat_group = esg_functions.get_group_id("tomcat")
         esg_functions.change_ownership_recursive(idp_service_app_home, tomcat_user, tomcat_group)
 
+    with pybash.pushd(config["esg_config_dir"]):
+        static_file = "esgf_idp_static.xml"
+        url = "{}/xml/{}".format(config["esgf_config_repo"], static_file)
+        esg_functions.download_update(static_file, url)
+
+    with pybash.pushd(config["esg_config_dir"]):
+        static_file = "esgf_ats_static.xml"
+        url = "{}/xml/{}".format(config["esgf_config_repo"], static_file)
+        esg_functions.download_update(static_file, url)
+
     write_idp_install_log(idp_service_app_home)
     esg_functions.write_security_lib_install_log()
 

--- a/index_node/esg_search.py
+++ b/index_node/esg_search.py
@@ -183,6 +183,7 @@ def setup_search_service():
     #Get utility script for crawling thredds sites
     fetch_crawl_launcher(esg_dist_url)
     fetch_index_optimization_launcher(esg_dist_url)
+    fetch_static_shards_file()
 
     #restart tomcat to put modifications in effect.
     # esg_tomcat_manager.start_tomcat()
@@ -212,10 +213,11 @@ def fetch_index_optimization_launcher(esg_dist_url):
         esg_functions.download_update(esgf_index_optimization_launcher, esgf_index_optimization_launcher_url)
         os.chmod(esgf_index_optimization_launcher, 0755)
 
-def fetch_static_shards_file(esg_dist_url):
-    static_shards_file = "esgf_shards_static.xml"
-    static_shards_url = "{}/lists/esgf_shards_static.xml".format(esg_dist_url)
-    esg_functions.download_update(static_shards_file, static_shards_url)
+def fetch_static_shards_file():
+    with pybash.pushd(config["esg_config_dir"]):
+        static_file = "esgf_shards_static.xml"
+        url = "{}/xml/{}".format(config["esgf_config_repo"], static_file)
+        esg_functions.download_update(static_file, url)
 
 
 def download_esg_search_war(esg_search_war_url):


### PR DESCRIPTION
While there is more opportunities for simplification here, this is
a good start to moving towards using the Github repos as an
alternative to the distribution mirrors.