### PR TITLE
Get the current environment every call using os.environ

### DIFF
--- a/data_node/esg_dashboard.py
+++ b/data_node/esg_dashboard.py
@@ -9,6 +9,7 @@ import yaml
 from git import Repo
 from clint.textui import progress
 from esgf_utilities import esg_functions
+from esgf_utilities import esg_property_manager
 from esgf_utilities import pybash
 from plumbum.commands import ProcessExecutionError
 
@@ -42,7 +43,8 @@ def setup_dashboard():
     print "******************************* \n"
 
     pybash.mkdir_p("/usr/local/tomcat/webapps/esgf-stats-api")
-    stats_api_url = os.path.join("http://", config["esgf_dist_mirror"], "dist", "devel", "esgf-stats-api", "esgf-stats-api.war")
+    dist_url = esg_property_manager.get_property("esg.dist.url")
+    stats_api_url = "{}/{}".format(dist_url, "esgf-stats-api/esgf-stats-api.war")
     download_stats_api_war(stats_api_url)
 
     with pybash.pushd("/usr/local/tomcat/webapps/esgf-stats-api"):

--- a/esgf_utilities/esg_functions.py
+++ b/esgf_utilities/esg_functions.py
@@ -942,6 +942,12 @@ def call_binary(binary_name, arguments):
     except ProcessExecutionError:
         logger.error("Could not find %s executable", binary_name)
         raise
+
+    for var in os.environ:
+        local.env[var] = os.environ[var]
+    for var in local.env:
+        logger.debug("env: %s", str(var))
+
     output = command.__getitem__(arguments) & TEE
 
     #special case where checking java version is displayed via stderr


### PR DESCRIPTION
This will add, and replace duplicates, in the `local.env` from `os.environ` each time an executable is called. This is to resolve #534 