### PR TITLE
Dashboard fixes

### DIFF
--- a/esgf_utilities/esg_functions.py
+++ b/esgf_utilities/esg_functions.py
@@ -930,13 +930,13 @@ def esgf_node_info():
         print info_file.read()
 
 
-def call_binary(binary_name, arguments):
+def call_binary(binary_name, arguments=None):
     '''Uses plumbum to make a call to a CLI binary.  The arguments should be passed as a list of strings'''
     RETURN_CODE = 0
     STDOUT = 1
     STDERR = 2
     logger.debug("binary_name: %s", binary_name)
-    logger.debug("arguments: %s", " ".join(arguments))
+    logger.debug("arguments: %s", arguments)
     try:
         command = local[binary_name]
     except ProcessExecutionError:
@@ -948,7 +948,10 @@ def call_binary(binary_name, arguments):
     for var in local.env:
         logger.debug("env: %s", str(var))
 
-    output = command.__getitem__(arguments) & TEE
+    if arguments is not None:
+        output = command.__getitem__(arguments) & TEE
+    else:
+        output = command.run_tee()
 
     #special case where checking java version is displayed via stderr
     if command.__str__() == '/usr/local/java/bin/java' and output[RETURN_CODE] == 0:


### PR DESCRIPTION
The dashboard install was incomplete. These changes do several things. 

First the download and extraction of `.war` files is a very common patter in the installer. The basic steps of download, extract and change ownership are taken here. This function could be moved to a better place, like esg_functions, to be referenced from other components.

Second, using the new `download_extract` functionality, the `esgf-dashboard.war` file is now being installed into the webapps.

Third, the python sub-component of the dashboard is being downloaded and installed with `easy_install`. This sub-component is used to setup the dashboard database.

Fourth, the startup process `ip.service` needs `liblzma.so.5`. This library is currently only being installed to the conda environment lib directory.

Fifth, the `make` and `make install` commands for the esgf-dashboard-ip sub-component require the headers from `geoip`. To resolve this `geoip` is now being installed from `yum`. This is regarding #536 