### PR TITLE
Fixed version of installer script

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -80,9 +80,9 @@ custom=0
 use_local_files=0
 
 progname="esg-node"
-script_maj_version="2.6"
-script_sub_version="0"
-script_version="v2.6.0-devel-release"
+script_maj_version="2.7"
+script_sub_version="1"
+script_version="v2.7.1-devel-release"
 script_release="Name"
 envfile="/etc/esg.env"
 


### PR DESCRIPTION
This is used to locate files from the "dist" mirror to download
software components for install.  Prior to this fix, the installer
was unable to locate the new "esg-search-4.16.0.jar" file.