### PR TITLE
Reverse apache-frontend checkout logic

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -1668,7 +1668,7 @@ update_apache_conf() {
 		popd
 	fi
 	pushd apache_frontend/apache-frontend;
-	if [ $devel -eq 1 ]; then
+	if [ $devel -eq 0 ]; then
 		git checkout $apache_frontend_tag;
 	else
 		git checkout master;
@@ -1784,7 +1784,7 @@ setup_apache_frontend() {
 	git clone ${apache_frontend_repo}
 	if [ $? -eq 0 ]; then
 		cd apache-frontend;
-		if [ $devel -eq 1 ]; then
+		if [ $devel -eq 0 ]; then
 			git checkout $apache_frontend_tag;
 			else
 			git checkout master;


### PR DESCRIPTION
In production mode, the installer checks out the "master" branch,
while in development it uses the specific release tag set in
"esg-init".  This appears to be the reverse of what's intended.