### PR TITLE
Security subsystem script needs to be run on index node as well

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -7199,7 +7199,7 @@ main() {
     #---------------------------------------
     # Security Services Installation...
     #---------------------------------------
-        [ $((sel & IDP_BIT+DATA_BIT )) != 0 ] && setup_subsystem security esgf-security $@
+        [ $((sel & IDP_BIT+DATA_BIT+INDEX_BIT)) != 0 ] && setup_subsystem security esgf-security $@
         [ $((sel & IDP_BIT )) != 0 ] && setup_subsystem idp esgf-idp $@
 
     #---------------------------------------


### PR DESCRIPTION
When installed as a standalone index node, the security XML configuration
files are missing otherwise.