### PR TITLE
 Dashboard component should only be installed on the data node

### DIFF
--- a/esg-functions
+++ b/esg-functions
@@ -705,14 +705,16 @@ check_tomcat_process() {
 #----------------------------------------------------------
 postgres_create_db() {
     # Creates a database if it does not already exist
+    local rc=0
     if [ -z "$(postgres_list_dbs ${1})" ] ; then
         #Create the database...
         echo "Creating ESGF database: [${1}]"
-        PGPASSWORD=${PGPASSWORD:-${pg_sys_acct_passwd}} createdb ${1} >& /dev/null
-        (( $? > 1 )) && echo " ERROR: Could not create esgf node database: ${node_db_name}" && return $?
+        PGPASSWORD=${PGPASSWORD:-${pg_sys_acct_passwd}} createdb ${1} >& /dev/null || rc=$?
+        [ ${rc} -ne 0 ] && echo " ERROR: Could not create esgf node database: ${node_db_name}"
     else
         echo "ESGF database [${1}] already exists, not creating."
     fi
+    return ${rc}
 }
 
 postgres_list_db_schemas() {

--- a/esg-node
+++ b/esg-node
@@ -7164,9 +7164,9 @@ main() {
         [ $((sel & TEST_BIT))    != 0 ] && test_tomcat
         [ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & DATA_BIT+COMPUTE_BIT)) != 0 ] && setup_tds ${upgrade_mode}
         [ $((sel & TEST_BIT))    != 0 ] && [ $((sel & DATA_BIT+COMPUTE_BIT)) != 0 ] && test_tds
-        [ $((sel & INSTALL_BIT)) != 0 ] && setup_subsystem node-manager esgf-node-manager #(tomcat off)
+        [ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & IDP_BIT+DATA_BIT)) != 0 ] && setup_subsystem node-manager esgf-node-manager #(tomcat off)
 
-        [ $((sel & INSTALL_BIT)) != 0 ] && setup_subsystem dashboard esgf-dashboard #(tomcat off)
+        [ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & DATA_BIT)) != 0 ] && setup_subsystem dashboard esgf-dashboard #(tomcat off)
 
         #[ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & DATA_BIT)) != 0 ] && setup_subsystem desktop esgf-desktop #(tomcat off)
 

--- a/esg-node
+++ b/esg-node
@@ -7164,7 +7164,7 @@ main() {
         [ $((sel & TEST_BIT))    != 0 ] && test_tomcat
         [ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & DATA_BIT+COMPUTE_BIT)) != 0 ] && setup_tds ${upgrade_mode}
         [ $((sel & TEST_BIT))    != 0 ] && [ $((sel & DATA_BIT+COMPUTE_BIT)) != 0 ] && test_tds
-        [ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & IDP_BIT+DATA_BIT)) != 0 ] && setup_subsystem node-manager esgf-node-manager #(tomcat off)
+        [ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & DATA_BIT)) != 0 ] && setup_subsystem node-manager esgf-node-manager #(tomcat off)
 
         [ $((sel & INSTALL_BIT)) != 0 ] && [ $((sel & DATA_BIT)) != 0 ] && setup_subsystem dashboard esgf-dashboard #(tomcat off)
 


### PR DESCRIPTION
This also fixes an issue that caused the security/node-manager database setup to
terminate prematurely. As a result, the node manager is now only required on the
data node (being a prereq for the dashboard install).