### PR TITLE
Support disabling automatic registration of Globus endpoint

### DIFF
--- a/esg-autoinstall
+++ b/esg-autoinstall
@@ -199,10 +199,10 @@ expect {
         send \n ; exp_continue
     }
     "Do you want to register the GridFTP server with Globus?" {
-        send Y\n ; exp_continue
+        send ${REGISTERGLOBUS}\n ; exp_continue
     }
     "Do you want to register the MyProxy server with Globus?" {
-        send Y\n ; exp_continue
+        send ${REGISTERGLOBUS}\n ; exp_continue
     }
     "Please provide a Globus username" {
         send ${GLOBUSUSER}\n ; exp_continue

--- a/esg-autoinstall.template
+++ b/esg-autoinstall.template
@@ -74,6 +74,9 @@ set ADMINEMAIL "root@localhost"
 # Should be be N for upgrade and Y for fresh install
 set GLOBUS "y"
 
+# Whether to register MyProxy/GridFTP endpoint with Globus.
+set REGISTERGLOBUS "Y"
+
 # Should thredds be installed?  Y for new installations and upgrades 2.5.9 or earlier
 # For now, N is recommended for 2.5.13 or later (until new version released)
 set THREDDS "Y"


### PR DESCRIPTION
Nodes that use a separate Globus/GridFTP DTN deployed outside the ESGF stack are unlikely to want ESGF to register itself automatically as a Globus endpoint. Note that the default behaviour is unchanged by this patch.