### PR TITLE
Don't install compute role unless explicitly requested

### DIFF
--- a/esg-autoinstall
+++ b/esg-autoinstall
@@ -123,6 +123,9 @@ expect {
     "Do you want to continue with ESGF Dashboard IP installation and setup?" {
         send \n ; exp_continue
     }
+    "Would you like to install the \"COMPUTE\" configuration to support this ?" {
+        send N\n ; exp_continue
+    }
     "Do you want to continue with LAS installation and setup?"  {
         send \n ; exp_continue
     }


### PR DESCRIPTION
If the compute role is not selected, then under certain conditions
the installer prompts to install it anyway.  Apart from the expect
script not expecting this, if the administrator didn't request the
compute role then obey their request (even if they're wrong :) ).