### PR TITLE
Do not use system netcdf library, use the version in the conda env

### DIFF
--- a/base/tomcat_conf/setenv.sh
+++ b/base/tomcat_conf/setenv.sh
@@ -2,7 +2,7 @@
 # script containing env variables for starting ESGF Tomcat
 
 export JAVA_OPTS="-Dtds.content.root.path=/esg/content"
-
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/conda/envs/esgf-pub/lib"
 #Sets the Java binary for Tomcat to use
 export JAVA_HOME="/usr/local/java"
 

--- a/data_node/thredds.py
+++ b/data_node/thredds.py
@@ -422,7 +422,6 @@ def setup_thredds():
     esg_dist_url = esg_property_manager.get_property("esg.dist.url")
 
     thredds_url = "{}/thredds/5.0/{}/thredds.war".format(esg_dist_url, config["tds_version"])
-    esg_functions.call_binary("yum", ["install", "-y", "netcdf-4.4.1"])
     download_thredds_war(thredds_url)
 
     with pybash.pushd("/usr/local/tomcat/webapps/thredds"):


### PR DESCRIPTION
At runtime thredds needs to know where libnetcdf.so and its
dependencies are by looking at the LD_LIBRARY_PATH variable. The
conda package "netCDF4" installs the shared object file into the
library directory of the conda environment.

This has been ready for awhile, but unable to test as the VM is unusable right now due to high CPU usage.