### PR TITLE
postgresql-devel is required by both the dashboard and esgcet

### DIFF
--- a/base/esg_postgres.py
+++ b/base/esg_postgres.py
@@ -2,6 +2,7 @@ import os
 import pwd
 import shutil
 import re
+from time import sleep
 import datetime
 import ConfigParser
 import logging
@@ -221,7 +222,8 @@ def start_postgres():
         initialize_postgres()
 
     esg_functions.call_binary("service", ["postgresql", "start"])
-
+    sleep(1)
+    
     if postgres_status():
         return True
 
@@ -256,7 +258,7 @@ def restart_postgres():
         logger.error("Restarting Postgres failed")
         logger.error(err)
         raise
-
+    sleep(1)
     postgres_status()
 
 

--- a/base/esg_postgres.py
+++ b/base/esg_postgres.py
@@ -82,8 +82,9 @@ def setup_postgres(default_continue_install="N"):
             #   a bit more functionality to be added here.
             backup_db("postgres", "postgres")
 
-    pkg_name = "postgresql-server-{}".format(config["postgress_version"])
-    esg_functions.call_binary("yum", ["-y", "install", pkg_name])
+    pg_name = "postgresql-server-{}".format(config["postgress_version"])
+    pg_devel = "postgresql-devel-{}".format(config["postgress_version"])
+    esg_functions.call_binary("yum", ["-y", "install", pg_name, pg_devel])
 
     initialize_postgres()
 

--- a/data_node/esg_dashboard.py
+++ b/data_node/esg_dashboard.py
@@ -138,8 +138,7 @@ def run_dashboard_script():
     DashDir = "/usr/local/esgf-dashboard-ip"
     GeoipDir = "/usr/local/geoip"
     Fed="no"
-    pg_devel = "postgresql-devel-{}".format(config["postgress_version"])
-    esg_functions.call_binary("yum", ["install", "-y", pg_devel, "geoip-devel"])
+    esg_functions.call_binary("yum", ["install", "-y", "geoip-devel"])
     with pybash.pushd("/usr/local"):
         clone_dashboard_repo()
         os.chdir("esgf-dashboard")


### PR DESCRIPTION
esgcet uses `pg_config` to determine the version of postgres installed when it is installed. `pg_config` is part of `postgresql-devel`. It is simpler to have it be installed in the postgres module.