### PR TITLE
A new process for mapping usernames to openids

### DIFF
--- a/idp_node/mapapp/myproxy-certificate-mapapp
+++ b/idp_node/mapapp/myproxy-certificate-mapapp
@@ -1,0 +1,10 @@
+#!/bin/bash
+username=$1
+if [ X"$username" = X ]; then
+    # no username given
+    exit 1
+fi
+
+# activate virtual env
+source /usr/local/conda/bin/activate esgf-pub && \
+    python openid_retriever.py $username

--- a/idp_node/mapapp/myproxy-certificate-mapapp
+++ b/idp_node/mapapp/myproxy-certificate-mapapp
@@ -4,7 +4,7 @@ if [ X"$username" = X ]; then
     # no username given
     exit 1
 fi
-
+cert_file="/var/lib/globus-connect-server/myproxy-ca/cacert.pem"
 # activate virtual env
 source /usr/local/conda/bin/activate esgf-pub && \
-    python openid_retriever.py $username
+    python /esg/config/myproxy/openid_retriever.py $username $cert_file

--- a/idp_node/mapapp/openid_retriever.py
+++ b/idp_node/mapapp/openid_retriever.py
@@ -4,7 +4,52 @@ import logging
 import os
 import sys
 
+import OpenSSL
 import psycopg2
+
+def get_openid(args, config_parser, esgf_home):
+
+    pass_file = os.path.join(esgf_home, "config", ".esg_pg_pass")
+    with open(pass_file, "rb") as filep:
+        password = filep.read().strip()
+
+    section = "installer.properties"
+
+    db = config_parser.get(section, "db.database")
+    host = config_parser.get(section, "db.host")
+    port = config_parser.get(section, "db.port")
+    user = config_parser.get(section, "db.user")
+    esgf_host = config_parser.get(section, "esgf.host")
+    gateway = "https://{}/esgf-idp/openid/%".format(esgf_host)
+
+    cs = "dbname=%s user=%s password=%s host=%s port=%s" % (db, user, password, host, port)
+    cs_no_pass = "dbname=%s user=%s host=%s port=%s" % (db, user, host, port)
+    logging.info(cs_no_pass)
+    conn = psycopg2.connect(cs)
+    cur = conn.cursor()
+    query = "SELECT DISTINCT openid FROM esgf_security.user"
+    query += " WHERE username=%(username)s AND openid LIKE %(gateway)s "
+    values = {
+        "username": args.username,
+        "gateway": gateway
+    }
+    logging.info(query, values)
+    cur.execute(query, values)
+    result = cur.fetchone()
+    if not result:
+        output = "No OpenID found for {}".format(args.username)
+        print output
+        logging.error(output)
+        sys.exit(1)
+    logging.info("OpenID Success: %s", result[0])
+    return result[0]
+
+def get_subject_line(args):
+
+    with open(args.cert_file) as cert:
+        cert_contents = cert.read()
+    cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_contents)
+    return cert.get_subject()
 
 def main():
 
@@ -12,6 +57,7 @@ def main():
         description="A script for querying the esgcet database for an OpenID, given a username"
     )
     parser.add_argument("username",  help="The username for which to query for the OpenID")
+    parser.add_argument("cert_file",  help="The username for which to query for the OpenID")
     args = parser.parse_args()
 
     try:
@@ -23,7 +69,7 @@ def main():
         format="%(asctime)s - %(message)s",
         datefmt='%m/%d/%Y %I:%M:%S %p',
         level=logging.DEBUG,
-        filename=os.path.join(esgf_home, "config", "myproxy", "mapapp.og"),
+        filename=os.path.join(esgf_home, "config", "myproxy", "mapapp.log"),
         maxBytes=2*1024*1024
     )
     properties_file = os.path.join(esgf_home, "config", "esgf.properties")
@@ -31,38 +77,15 @@ def main():
     config_parser = ConfigParser.SafeConfigParser(allow_no_value=True)
     config_parser.read(properties_file)
 
-    section = "installer.properties"
-
-    db = config_parser.get(section, "db.database")
-    host = config_parser.get(section, "db.host")
-    port = config_parser.get(section, "db.port")
-    user = config_parser.get(section, "db.user")
-    esgf_host = config_parser.get(section, "esgf.host")
-    gateway = "https://{}/esgf-idp/openid/%".format(esgf_host)
-
-    pass_file = os.path.join(esgf_home, "config", ".esg_pg_pass")
-    with open(pass_file, "rb") as filep:
-        password = filep.read().strip()
-
-    cs = "dbname=%s user=%s password=%s host=%s port=%s" % (db, user, password, host, port)
-    conn = psycopg2.connect(cs)
-    cur = conn.cursor()
-    query = "SELECT DISTINCT openid FROM esgf_security.user"
-    query += " WHERE username=%(username)s AND openid LIKE %(gateway)s "
-    values = {
-        "username": args.username,
-        "gateway": gateway
-    }
-    cur.execute(query, values)
-    result = cur.fetchone()
-    if not result:
-        output = "No OpenID found for {}".format(args.username)
-        output += "\ndbname=%s user=%s host=%s port=%s\n" % (db, user, host, port)
-        output += query % values
-        print output
-        logging.error(output)
-        sys.exit(1)
-    logging.info("Success %s", result[0])
-    print result[0]
+    openid = get_openid(args, config_parser, esgf_home)
+    subject_line = get_subject_line(args)
+    output = "/O={}/OU={}/CN={}"
+    output = output.format(
+        subject_line.O,
+        subject_line.OU,
+        openid
+    )
+    print output
+    logging.info("Sent to myproxy: %s", output)
 
 main()

--- a/idp_node/mapapp/openid_retriever.py
+++ b/idp_node/mapapp/openid_retriever.py
@@ -46,6 +46,7 @@ def get_openid(args, config_parser, esgf_home):
 
 def get_subject_line(args):
 
+    logging.info("Loading cert file: %s", args.cert_file)
     with open(args.cert_file) as cert:
         cert_contents = cert.read()
     cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_contents)

--- a/idp_node/mapapp/openid_retriever.py
+++ b/idp_node/mapapp/openid_retriever.py
@@ -1,0 +1,68 @@
+import argparse
+import ConfigParser
+import logging
+import os
+import sys
+
+import psycopg2
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="A script for querying the esgcet database for an OpenID, given a username"
+    )
+    parser.add_argument("username",  help="The username for which to query for the OpenID")
+    args = parser.parse_args()
+
+    try:
+        esgf_home = os.environ["ESGF_HOME"]
+    except KeyError:
+        esgf_home = os.path.join(os.sep, "esg")
+
+    logging.basicConfig(
+        format="%(asctime)s - %(message)s",
+        datefmt='%m/%d/%Y %I:%M:%S %p',
+        level=logging.DEBUG,
+        filename=os.path.join(esgf_home, "config", "myproxy", "mapapp.og"),
+        maxBytes=2*1024*1024
+    )
+    properties_file = os.path.join(esgf_home, "config", "esgf.properties")
+
+    config_parser = ConfigParser.SafeConfigParser(allow_no_value=True)
+    config_parser.read(properties_file)
+
+    section = "installer.properties"
+
+    db = config_parser.get(section, "db.database")
+    host = config_parser.get(section, "db.host")
+    port = config_parser.get(section, "db.port")
+    user = config_parser.get(section, "db.user")
+    esgf_host = config_parser.get(section, "esgf.host")
+    gateway = "https://{}/esgf-idp/openid/%".format(esgf_host)
+
+    pass_file = os.path.join(esgf_home, "config", ".esg_pg_pass")
+    with open(pass_file, "rb") as filep:
+        password = filep.read().strip()
+
+    cs = "dbname=%s user=%s password=%s host=%s port=%s" % (db, user, password, host, port)
+    conn = psycopg2.connect(cs)
+    cur = conn.cursor()
+    query = "SELECT DISTINCT openid FROM esgf_security.user"
+    query += " WHERE username=%(username)s AND openid LIKE %(gateway)s "
+    values = {
+        "username": args.username,
+        "gateway": gateway
+    }
+    cur.execute(query, values)
+    result = cur.fetchone()
+    if not result:
+        output = "No OpenID found for {}".format(args.username)
+        output += "\ndbname=%s user=%s host=%s port=%s\n" % (db, user, host, port)
+        output += query % values
+        print output
+        logging.error(output)
+        sys.exit(1)
+    logging.info("Success %s", result[0])
+    print result[0]
+
+main()

--- a/idp_node/myproxy.py
+++ b/idp_node/myproxy.py
@@ -186,7 +186,7 @@ def config_myproxy_server(globus_location, install_mode="install"):
             esg_functions.call_binary("javac", ["-classpath", java_class_path_string, "ESGOpenIDRetriever.java"])
             esg_functions.call_binary("javac", ["-classpath", java_class_path_string, "ESGGroupRetriever.java"])
 
-        fetch_myproxy_certificate_mapapp()
+        copy_myproxy_certificate_mapapp()
         edit_pam_pgsql_conf()
         #--------------------
         # Fetch -> pam resource file used for myproxy
@@ -274,20 +274,17 @@ def copy_myproxy_server_config(config_path="/esg/config/myproxy/myproxy-server.c
 # Configuration File Editing Functions
 ############################################
 
-def fetch_myproxy_certificate_mapapp():
+def copy_myproxy_certificate_mapapp():
     myproxy_config_dir = os.path.join(config["esg_config_dir"], "myproxy")
     pybash.mkdir_p(myproxy_config_dir)
-    with pybash.pushd(myproxy_config_dir):
-        mapapp_file = "myproxy-certificate-mapapp"
-        print "Downloading configuration file: {}".format(mapapp_file)
-        myproxy_dist_url_base = "{}/globus/myproxy".format(esg_property_manager.get_property("esg.root.url"))
-        try:
-            esg_functions.download_update(mapapp_file, myproxy_dist_url_base+"/{}".format(mapapp_file))
-        except HTTPError:
-            raise
 
-        os.chmod(mapapp_file, 0751)
-        esg_functions.replace_string_in_file(mapapp_file, "/root/.globus/simpleCA/cacert.pem", "/var/lib/globus-connect-server/myproxy-ca/cacert.pem")
+    mapapp_file = "mapapp/myproxy-certificate-mapapp"
+    retriever_file = "mapapp/openid_retriever.py"
+
+    os.chmod(mapapp_file, 0751)
+
+    shutil.copy2(mapapp_file, myproxy_config_dir)
+    shutil.copy2(retriever_file, myproxy_config_dir)
 
 def edit_pam_pgsql_conf():
     with pybash.pushd("/etc"):


### PR DESCRIPTION
This is to replace the old java application that performed this process and will resolve #589 and #482. It still needs to be copied into place, `/esg/config/myproxy/`, by the installer.