### PR TITLE
require cdf2cim 0.3.0.0

### DIFF
--- a/esg-node
+++ b/esg-node
@@ -1125,7 +1125,7 @@ setup_esgcet() {
     fi
 
     $pipcmd sqlalchemy_migrate
-    $pipcmd cdf2cim==0.2.3.0
+    $pipcmd cdf2cim==0.3.0.0
     $pipcmd cf-python==2.2.1
     $pipcmd hurry
     $pipcmd psycopg2-binary


### PR DESCRIPTION
@davidhassell tells me that cdf2cim 0.3.0.0 is ready. Bumping version in ESGF installer (though surprised to find that it is defined in `esg-node` rather than in `esg-init`).