### PR TITLE
Install cmor for use by the publisher, requires 'cmip6_cv

### DIFF
--- a/esg_bootstrap.sh
+++ b/esg_bootstrap.sh
@@ -44,7 +44,8 @@ install_miniconda(){
         echo "-----------------------------------"
         echo
         PATH=${CDAT_HOME}/bin:$PATH
-        conda create -y -n esgf-pub "python<3" cdutil lxml requests psycopg2 decorator Tempita \
+        conda create -y -n esgf-pub "python<3" cdutil cmor \
+        lxml requests psycopg2 decorator Tempita \
         GitPython coloredlogs pip progressbar2 pyOpenSSL pylint \
         setuptools semver Pyyaml configobj psutil \
         -c conda-forge -c cdat


### PR DESCRIPTION
`cmor` was not being installed and `esgf-publisher` depends on `cmip6_cv` which is lives in `cmor`. It is now being installed in the bootstrapper, when the `esgf-pub` conda environment is created. This is to resolve #603 .