### PR TITLE
Do not start apache until end of installer or via start flag

### DIFF
--- a/base/esg_apache_manager.py
+++ b/base/esg_apache_manager.py
@@ -136,7 +136,6 @@ def main():
     install_mod_wsgi()
     make_python_eggs_dir()
     copy_apache_conf_files()
-    start_apache()
 
 
 if __name__ == '__main__':

--- a/esg_node.py
+++ b/esg_node.py
@@ -427,8 +427,9 @@ def system_launch(esg_dist_url, node_type_list, script_version, script_release):
     esg_functions.update_fileupload_jar()
     esg_functions.setup_whitelist_files()
 
-    esg_cli_argument_manager.start(node_type_list)
     esg_cert_manager.check_for_commercial_ca()
+    esg_cli_argument_manager.start(node_type_list)
+
     install_bash_completion_file(esg_dist_url)
     done_remark(node_type_list)
     write_script_version_file(script_version)

--- a/esg_node.py
+++ b/esg_node.py
@@ -427,6 +427,7 @@ def system_launch(esg_dist_url, node_type_list, script_version, script_release):
     esg_functions.update_fileupload_jar()
     esg_functions.setup_whitelist_files()
 
+    esg_cli_argument_manager.run_startup_hooks(node_type_list)
     esg_cert_manager.check_for_commercial_ca()
     esg_cli_argument_manager.start(node_type_list)
 

--- a/esgf_utilities/esg_cli_argument_manager.py
+++ b/esgf_utilities/esg_cli_argument_manager.py
@@ -54,11 +54,11 @@ def run_startup_hooks(node_type_list):
         esg_property_manager.set_property("node_auto_fetch_certs", "true")
 
     if esg_property_manager.get_property("node_auto_fetch_certs") == "true":
-         print "Fetching federation certificates... "
-         esg_truststore_manager.fetch_esgf_certificates()
+        print "Fetching federation certificates... "
+        esg_truststore_manager.fetch_esgf_certificates()
 
-         print "Fetching federation truststore..... "
-         esg_truststore_manager.fetch_esgf_truststore()
+        print "Fetching federation truststore..... "
+        esg_truststore_manager.fetch_esgf_truststore()
 
 def start(node_types):
     '''Start ESGF Services'''


### PR DESCRIPTION
Since certificates are installed at the end of the installation
process, starting here will cause them to not be properly
discovered. This allows the start at the end to start httpd.