### PR TITLE
Properly check if solr is running and cleanup unused imports

### DIFF
--- a/base/esg_apache_manager.py
+++ b/base/esg_apache_manager.py
@@ -9,6 +9,7 @@ import yaml
 from esgf_utilities import esg_property_manager
 from esgf_utilities import pybash
 from esgf_utilities import esg_functions
+from plumbum.commands import ProcessExecutionError
 
 logger = logging.getLogger("esgf_logger" + "." + __name__)
 
@@ -37,7 +38,14 @@ def restart_apache():
 
 def check_apache_status():
     '''Check httpd status'''
-    esg_functions.call_binary("service", ["httpd", "status"])
+    try:
+        esg_functions.call_binary("service", ["httpd", "status"])
+    except ProcessExecutionError as error:
+        # Return code of 3 indicates process is not running
+        if error.retcode == 3:
+            return False
+        raise
+    return True
 
 
 def run_apache_config_test():

--- a/esgf_utilities/esg_cli_argument_manager.py
+++ b/esgf_utilities/esg_cli_argument_manager.py
@@ -4,20 +4,18 @@ import shutil
 import logging
 import argparse
 import psutil
-import pprint
 import ConfigParser
 from time import sleep
 import yaml
 from esgf_utilities import esg_functions
-from esgf_utilities import pybash
 from esgf_utilities import esg_property_manager
 from esgf_utilities import esg_version_manager
-from esgf_utilities import esg_cert_manager, esg_truststore_manager
+from esgf_utilities import esg_truststore_manager
 from base import esg_apache_manager
 from base import esg_tomcat_manager
 from base import esg_postgres
 from data_node import esg_publisher, orp
-from esgf_utilities.esg_exceptions import NoNodeTypeError, InvalidNodeTypeError
+from esgf_utilities.esg_exceptions import InvalidNodeTypeError
 from idp_node import globus, gridftp, myproxy, esg_security
 from index_node import solr, esg_search
 from plumbum.commands import ProcessExecutionError
@@ -190,7 +188,7 @@ def get_node_status():
         print "\n*******************************"
         print "Solr status"
         print "******************************* \n"
-        if not solr.check_solr_process():
+        if not solr.solr_status():
             node_running = False
 
     print "\n*******************************"

--- a/index_node/solr.py
+++ b/index_node/solr.py
@@ -88,7 +88,7 @@ def start_solr(solr_config_type, port_number, SOLR_INSTALL_DIR="/usr/local/solr"
 def solr_status():
     '''Check the status of solr'''
     try:
-        result = esg_functions.call_binary("/usr/local/solr/bin/solr", ["status"])
+        esg_functions.call_binary("/usr/local/solr/bin/solr", ["status"])
     except ProcessExecutionError as error:
         # 3 is the return code if not running
         if error.retcode==3:


### PR DESCRIPTION
The output when starting was giving bad information regarding the status of solr. Theses changes are intended to give the correct information to the user.