### PR TITLE
No longer run re-initialize thredds

### DIFF
--- a/esg_init.py
+++ b/esg_init.py
@@ -36,8 +36,8 @@ def init():
 
     cdat_version = "2.2.0"
 
-    esgcet_version = "3.5.4"
-    publisher_tag = "v3.5.4"
+    esgcet_version = "2.6a0"
+    publisher_tag = "v2.6a0"
 
     esgprep_version="2.8.1"
     cmor_version="3.3.2"


### PR DESCRIPTION
This is to resolve #617 . After moving to version 3.5.4 of esg-publisher, errors began occurring (#617). This was a result of the re-initialization of thredds that `esgsetup` does in 3.5.4. Tag v2.6a0 has this step removed from `esgsetup`. This was done by @sashakames .  