### PR TITLE
Use non-zero serial number when signing the new cert

### DIFF
--- a/esgf_utilities/CA.py
+++ b/esgf_utilities/CA.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import glob
 import logging
+import random
 import tarfile
 import OpenSSL
 import errno
@@ -85,7 +86,7 @@ def sign_request(ca_req):
         logger.exception("Certificate is not correct.")
         raise
 
-    newcert = esg_cert_manager.create_certificate(ca_req, (ca_cert, private_cakey), 0, (0, 60*60*24*365*5))
+    newcert = esg_cert_manager.create_certificate(ca_req, (ca_cert, private_cakey), random.randint(1, pow(2, 30)), (0, 60*60*24*365*5))
 
     with open('newcert.pem', 'w') as ca:
         ca.write(


### PR DESCRIPTION
The zero serial that was replaced previously was not the one causing the problem, probably okay, maybe good, that that one was changed as well. This should resolve the browsers rejecting this certificate because of duplicate serial number.