### PR TITLE
This is the required prefix if yum install geoip libraries via geoip-devel

### DIFF
--- a/data_node/esg_dashboard.py
+++ b/data_node/esg_dashboard.py
@@ -149,7 +149,7 @@ def run_dashboard_script():
     # Required property for ip.service start, copied from 2.x
     # TODO Figure out what this does and if it is valid
     esg_property_manager.set_property("dashboard.ip.app.home", dashdir)
-    geoipdir = "/usr/local/geoip"
+    geoipdir = "/usr"
     fed = "no"
     esg_functions.call_binary("yum", ["install", "-y", "geoip-devel"])
     with pybash.pushd("/usr/local"):


### PR DESCRIPTION
This may be OS dependent, but that is not a concern of the project at the moment. With the `/usr` prefix this should allow the esgf-dashboard-ip process to find all the needed files. This has been tested manually. This is to continue to resolve #615 and #462.