### PR TITLE
!WIP Exit zero after starting node services

### DIFF
--- a/esgf_utilities/esg_cli_argument_manager.py
+++ b/esgf_utilities/esg_cli_argument_manager.py
@@ -394,7 +394,8 @@ def process_arguments():
         logger.debug("args: %s", args)
         node_type_list = esg_functions.get_node_type()
         logger.debug("START SERVICES: %s", node_type_list)
-        return start(node_type_list)
+        start(node_type_list)
+        sys.exit(0)
     elif args.stop:
         logger.debug("STOP SERVICES")
         node_type_list = esg_functions.get_node_type()


### PR DESCRIPTION
The program would continue executing until it hit an error when the --start command was invoked. This causes the program to exit with a zero return code as soon as the start function is done executing, avoiding the unneeded output and resultant error.