### PR TITLE
!WIP Have pip install most components until conda improves install time

### DIFF
--- a/esg_bootstrap.sh
+++ b/esg_bootstrap.sh
@@ -44,12 +44,7 @@ install_miniconda(){
         echo "-----------------------------------"
         echo
         PATH=${CDAT_HOME}/bin:$PATH
-        conda create -y -n esgf-pub "python<3" cdutil cmor \
-        lxml requests psycopg2 decorator Tempita \
-        GitPython coloredlogs pip progressbar2 pyOpenSSL pylint \
-        setuptools semver Pyyaml configobj psutil \
-        -c conda-forge -c cdat
-
+        conda create -y -n esgf-pub "python<3" cdutil cmor -c conda-forge
   popd
 
 }
@@ -63,6 +58,10 @@ install_dependencies_pip(){
   # activate virtual env and fetch some pre-requisites
   source ${CDAT_HOME}/bin/activate esgf-pub && \
 
+      pip install --upgrade pip
+      pip install coloredlogs GitPython progressbar2 pyOpenSSL \
+                  lxml requests psycopg2 decorator Tempita \
+                  setuptools semver Pyyaml configobj psutil
       pip install -r requirements.txt
 
   source deactivate


### PR DESCRIPTION
conda's install process takes a significant amount of time compared
to pip's install. To improve bootstrap time it is preffered to use
pip to install those packages which are available to it. Also, the
-c cdat specification does not appear to be doing anything and may
be increasing the "Solving Environment" time. Tests of this install
process indicate about a 40-50 second speed up compared to the
previous process.