### PR TITLE
Pin the requests version to version required by esgprep

### DIFF
--- a/esg_bootstrap.sh
+++ b/esg_bootstrap.sh
@@ -60,7 +60,7 @@ install_dependencies_pip(){
 
       pip install --upgrade pip
       pip install coloredlogs GitPython progressbar2 pyOpenSSL \
-                  lxml requests psycopg2 decorator Tempita \
+                  lxml "requests==2.19.1" psycopg2 decorator Tempita \
                   setuptools semver Pyyaml configparser psutil
       pip install -r requirements.txt
 


### PR DESCRIPTION
esgprep requires 'requests==2.19.1'. pip does not resolve
dependencies across multiple pip install commands, it only warns
about them. 'requests' 2.20.0 was released Oct 18th 2018.