### PR TITLE
Truststore insert

### DIFF
--- a/esgf_utilities/esg_truststore_manager.py
+++ b/esgf_utilities/esg_truststore_manager.py
@@ -159,7 +159,7 @@ def _insert_cert_into_truststore(cert_file, truststore_file):
         open(cert_file).read()
     )
     dumped_cert_der = OpenSSL.crypto.dump_certificate(
-        crypto.FILETYPE_ASN1,
+        OpenSSL.crypto.FILETYPE_ASN1,
         cert_pem
     )
 

--- a/esgf_utilities/esg_truststore_manager.py
+++ b/esgf_utilities/esg_truststore_manager.py
@@ -50,7 +50,7 @@ def rebuild_truststore(truststore_file, certs_dir=config["globus_global_certs_di
 
     cert_files = glob.glob('{certs_dir}/*.0'.format(certs_dir=certs_dir))
     for cert in cert_files:
-        _insert_cert_into_truststore(cert, truststore_file, tmp_dir)
+        _insert_cert_into_truststore(cert, truststore_file)
     shutil.rmtree(tmp_dir)
 
     sync_with_java_truststore(truststore_file)
@@ -134,7 +134,7 @@ def sync_with_java_truststore(truststore_file):
     os.chown(jssecacerts_path, esg_functions.get_user_id("root"), esg_functions.get_group_id("root"))
 
 
-def _insert_cert_into_truststore(cert_file, truststore_file, tmp_dir):
+def _insert_cert_into_truststore(cert_file, truststore_file):
     '''
     Takes full path to a pem certificate file and incorporates it into the
     given truststore
@@ -163,12 +163,12 @@ def _insert_cert_into_truststore(cert_file, truststore_file, tmp_dir):
         cert_pem
     )
 
-    alias = cert_hash
     truststore = jks.KeyStore.load(
         truststore_file,
         config["truststore_password"]
     )
 
+    alias = cert_hash
     truststore.entries[alias] = jks.TrustedCertEntry.new(
         alias,
         dumped_cert_der
@@ -325,7 +325,7 @@ def fetch_esgf_truststore(truststore_file=config["truststore_file"], apache_trus
         simpleCA_cert_hash = get_certificate_subject_hash(simple_CA_cert)
 
         simpleCA_cert_hash_file = os.path.join(globus_certs_dir, simpleCA_cert_hash+".0")
-        _insert_cert_into_truststore(simpleCA_cert_hash_file, truststore_file, "/tmp/esg_scratch")
+        _insert_cert_into_truststore(simpleCA_cert_hash_file, truststore_file)
 
         add_my_cert_to_truststore()
 

--- a/esgf_utilities/esg_truststore_manager.py
+++ b/esgf_utilities/esg_truststore_manager.py
@@ -46,13 +46,9 @@ def rebuild_truststore(truststore_file, certs_dir=config["globus_global_certs_di
     if not os.path.isfile(truststore_file):
         create_new_truststore(truststore_file)
 
-    tmp_dir = "/tmp/esg_scratch"
-    pybash.mkdir_p(tmp_dir)
-
     cert_files = glob.glob('{certs_dir}/*.0'.format(certs_dir=certs_dir))
     for cert in cert_files:
         _insert_cert_into_truststore(cert, truststore_file)
-    shutil.rmtree(tmp_dir)
 
     sync_with_java_truststore(truststore_file)
     os.chown(truststore_file, esg_functions.get_user_id("tomcat"), esg_functions.get_group_id("tomcat"))
@@ -213,15 +209,6 @@ def add_simpleca_cert_to_globus(globus_certs_dir="/etc/grid-security/certificate
 
             with pybash.pushd("globus_simple_ca_{}_setup-0".format(simpleCA_cert_hash)):
                 shutil.copyfile("{}.signing_policy".format(simpleCA_cert_hash), "{}/{}.signing_policy".format(globus_certs_dir, simpleCA_cert_hash))
-
-            #Copy cert to ROOT webapp
-            if os.path.isdir("/usr/local/tomcat/webapps/ROOT"):
-                with open('/usr/local/tomcat/webapps/ROOT/cacert.pem', 'w') as ca:
-                    ca.write(
-                        OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_obj).decode('utf-8')
-                        )
-                print " My CA Cert now posted @ http://{}/cacert.pem ".format(socket.getfqdn())
-                os.chmod("/usr/local/tomcat/webapps/ROOT/cacert.pem", 0644)
 
         os.chmod(globus_certs_dir, 0755)
         esg_functions.change_permissions_recursive(globus_certs_dir, 0644)

--- a/esgf_utilities/esg_truststore_manager.py
+++ b/esgf_utilities/esg_truststore_manager.py
@@ -7,6 +7,7 @@ import socket
 import ConfigParser
 import yaml
 import OpenSSL
+import jks
 import pybash
 import esg_functions
 from esgf_utilities import esg_property_manager


### PR DESCRIPTION
Although the existing truststore insert functionality was not broken, it was slow and outputted potentially misleading information. It would have Java exceptions saying each alias did not exist. While this was a result of an attempted deletion, it still appeared there was a problem. These changes use the `pyjks` module, as well as the `OpenSSL` module, to insert certificates into the truststore.