### PR TITLE
SLCS env

### DIFF
--- a/base/apache_conf/esgf-httpd.conf
+++ b/base/apache_conf/esgf-httpd.conf
@@ -257,6 +257,8 @@ NameVirtualHost *:443
 	ProxyPass /esgf-stats-api	ajp://localhost:8223/esgf-stats-api
 	ProxyPassReverse /esgf-stats-api	ajp://localhost:8223/esgf-stats-api
 
+	ProxyPass /esgf-slcs   http://localhost:8888/esgf-slcs
+	ProxyPassReverse /esgf-slcs   http://localhost:8888/esgf-slcs
 
 	#WSGIDaemonProcess demo user=apache group=apache threads=5
 	#WSGIScriptAlias /api/demo /opt/esgf/flaskdemo/demo/demo.wsgi
@@ -275,19 +277,6 @@ NameVirtualHost *:443
     </Directory>
     <Location /esgf-nm>
        WSGIProcessGroup esgfnm
-       WSGIApplicationGroup %{GLOBAL}
-    </Location>
-
-   WSGIDaemonProcess esgfslcs python-path=/usr/local/esgf-slcs-server/venv/lib/python2.7/site-packages:/usr/local/esgf-slcs-server/src/esgf_slcs_server user=apache group=apache threads=5
-    WSGIScriptAlias /esgf-slcs /usr/local/esgf-slcs-server/src/esgf_slcs_server/esgf_slcs_server/wsgi.py
-    WSGIPassAuthorization On
-    <Directory /usr/local/esgf-slcs-server/src/esgf_slcs_server/esgf_slcs_server>
-                Order allow,deny
-                Allow from all
-                AllowOverride None
-    </Directory>
-    <Location /esgf-slcs>
-       WSGIProcessGroup esgfslcs
        WSGIApplicationGroup %{GLOBAL}
     </Location>
 

--- a/esgf_utilities/esg_cli_argument_manager.py
+++ b/esgf_utilities/esg_cli_argument_manager.py
@@ -16,7 +16,7 @@ from base import esg_tomcat_manager
 from base import esg_postgres
 from data_node import esg_dashboard, esg_publisher, orp
 from esgf_utilities.esg_exceptions import NoNodeTypeError, InvalidNodeTypeError
-from idp_node import globus, gridftp, myproxy, esg_security
+from idp_node import globus, gridftp, myproxy, esg_security, idp
 from index_node import solr, esg_search
 from plumbum.commands import ProcessExecutionError
 
@@ -101,6 +101,7 @@ def start(node_types):
             globus.start_globus("IDP")
         except ProcessExecutionError, error:
             logger.error("Could not start globus: %s", error)
+        idp.slcs_apachectl("start")
 
     if "INDEX" in node_types:
         esg_search.start_search_services()
@@ -120,6 +121,7 @@ def stop(node_types):
 
     if "IDP" in node_types:
         globus.stop_globus("IDP")
+        idp.slcs_apachectl("stop")
 
     if "INDEX" in node_types:
         solr_shards = solr.read_shard_config()

--- a/esgf_utilities/esg_functions.py
+++ b/esgf_utilities/esg_functions.py
@@ -908,13 +908,19 @@ def esgf_node_info():
         print info_file.read()
 
 
-def call_binary(binary_name, arguments=None, silent=False):
+def call_binary(binary_name, arguments=None, silent=False, conda_env=None):
     '''Uses plumbum to make a call to a CLI binary.  The arguments should be passed as a list of strings'''
     RETURN_CODE = 0
     STDOUT = 1
     STDERR = 2
     logger.debug("binary_name: %s", binary_name)
     logger.debug("arguments: %s", arguments)
+    if conda_env is not None:
+        if arguments is not None:
+            arguments = [conda_env, binary_name] + arguments
+        else:
+            arguments = [conda_env, binary_name]
+        binary_name = os.path.join(os.path.dirname(__file__), "run_in_env.sh")
     try:
         command = local[binary_name]
     except ProcessExecutionError:

--- a/esgf_utilities/run_in_env.sh
+++ b/esgf_utilities/run_in_env.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+env_name=$1
+cmd=$2
+source ${CONDA_EXE%conda}activate $env_name && \
+    args="$cmd"
+    # Enquote args to avoid special character problems
+    for arg in ${@:3}; do
+      args="$args '$arg'"
+    done
+    eval "$args"
+    rc=$?
+conda deactivate
+exit $rc

--- a/idp_node/idp.py
+++ b/idp_node/idp.py
@@ -124,7 +124,9 @@ def setup_slcs():
     print "Setting up SLCS Oauth Server"
     print "*******************************"
 
-    esg_functions.call_binary("yum", ["-y", "-q", "install", "epel-release", "ansible"])
+    slcs_env = "slcs-env"
+    esg_functions.call_binary("conda", ["create", "-y", "-n", slcs_env, "python<3", "pip"])
+    esg_functions.call_binary("pip", ["install", "-y", "mod_wsgi<4.6", "ansible"], conda_env=slcs_env)
 
     #create slcs Database
     esg_postgres.create_database("slcsdb")
@@ -166,7 +168,15 @@ def setup_slcs():
             pybash.mkdir_p("/usr/local/esgf-slcs-server/src")
             esg_functions.change_ownership_recursive("/usr/local/esgf-slcs-server", apache_user, apache_group)
 
-            esg_functions.call_binary("ansible-playbook", ["-i", "playbook/inventories/localhost", "-e", "@playbook/overrides/production_venv_only.yml", "playbook/playbook.yml"])
+            esg_functions.call_binary(
+                "ansible-playbook",
+                [
+                    "-i", "playbook/inventories/localhost",
+                    "-e", "@playbook/overrides/production_venv_only.yml",
+                    "playbook/playbook.yml"
+                ],
+                conda_env=slcs_env
+            )
 
 def main():
     '''Main function'''

--- a/idp_node/idp.py
+++ b/idp_node/idp.py
@@ -141,7 +141,7 @@ def setup_slcs():
         with pybash.pushd("esgf-slcs-server-playbook"):
             #TODO: extract to function
             publisher_repo_local = Repo(os.getcwd())
-            publisher_repo_local.git.checkout("3.0")
+            publisher_repo_local.git.checkout("slcs_conda_env")
 
             esg_functions.change_ownership_recursive("/var/lib/globus-connect-server/myproxy-ca/", gid=apache_group)
 

--- a/idp_node/idp.py
+++ b/idp_node/idp.py
@@ -141,7 +141,7 @@ def setup_slcs():
         with pybash.pushd("esgf-slcs-server-playbook"):
             #TODO: extract to function
             publisher_repo_local = Repo(os.getcwd())
-            publisher_repo_local.git.checkout("slcs_conda_env")
+            publisher_repo_local.git.checkout("3.0")
 
             esg_functions.change_ownership_recursive("/var/lib/globus-connect-server/myproxy-ca/", gid=apache_group)
 

--- a/idp_node/idp.py
+++ b/idp_node/idp.py
@@ -126,7 +126,7 @@ def setup_slcs():
 
     slcs_env = "slcs-env"
     esg_functions.call_binary("conda", ["create", "-y", "-n", slcs_env, "python<3", "pip"])
-    esg_functions.call_binary("pip", ["install", "-y", "mod_wsgi<4.6", "ansible"], conda_env=slcs_env)
+    esg_functions.call_binary("pip", ["install", "mod_wsgi<4.6", "ansible"], conda_env=slcs_env)
 
     #create slcs Database
     esg_postgres.create_database("slcsdb")

--- a/idp_node/idp.py
+++ b/idp_node/idp.py
@@ -182,9 +182,8 @@ def setup_slcs():
         esg_functions.call_binary(
             "mod_wsgi-express",
             [
-                "start-server",
+                "setup-server",
                 "esgf_slcs_server/wsgi.py",
-                "--setup-only",
                 "--server-root", "/etc/slcs-wsgi-8888",
                 "--user", "apache",
                 "--group", "apache",

--- a/idp_node/idp.py
+++ b/idp_node/idp.py
@@ -176,6 +176,7 @@ def setup_slcs():
                 ],
                 conda_env=slcs_env
             )
+            esg_functions.change_ownership_recursive("/usr/local/esgf-slcs-server", apache_user, apache_group)
 
     # Setup the mod_wsgi-express server. Note this does NOT start/stop/restart it.
     with pybash.pushd("/usr/local/esgf-slcs-server/src/esgf_slcs_server"):

--- a/idp_node/idp.py
+++ b/idp_node/idp.py
@@ -158,7 +158,6 @@ def setup_slcs():
             db_password = esg_functions.get_postgres_password()
             production_venv_only["esgf_slcsdb"]["password"] = db_password
             production_venv_only["esgf_userdb"]["password"] = db_password
-            production_venv_only["virtualenv_command"] = distutils.spawn.find_executable("virtualenv")
 
             with open('playbook/overrides/production_venv_only.yml', 'w') as yaml_file:
                 yaml.dump(production_venv_only, yaml_file)

--- a/idp_node/idp.py
+++ b/idp_node/idp.py
@@ -177,6 +177,33 @@ def setup_slcs():
                 conda_env=slcs_env
             )
 
+    # Setup the mod_wsgi-express server. Note this does NOT start/stop/restart it.
+    with pybash.pushd("/usr/local/esgf-slcs-server/src/esgf_slcs_server"):
+        esg_functions.call_binary(
+            "mod_wsgi-express",
+            [
+                "start-server",
+                "esgf_slcs_server/wsgi.py",
+                "--setup-only",
+                "--server-root", "/etc/slcs-wsgi-8888",
+                "--user", "apache",
+                "--group", "apache",
+                "--host", "localhost",
+                "--port", "8888",
+                "--mount-point", "/esgf-slcs",
+                "--url-alias", "/static", "/var/www/static"
+            ],
+            conda_env=slcs_env
+        )
+
+def slcs_apachectl(directive):
+    esg_functions.call_binary(
+        "/etc/slcs-wsgi-8888/apachectl",
+        [
+            directive
+        ]
+    )
+
 def main():
     '''Main function'''
     setup_idp()


### PR DESCRIPTION
The ESGF-SLCS component is now being deployed differently. The deployment is now properly utilizing the isolation features of `conda` and the independent server features of `mod_wsgi-express`. Now ESGF-SLCS is in its own conda environment, currently named `slcs-env`, although the name does not really matter. The `mod_wsgi-express` server is an httpd server that hosts to the localhost, currently port 8888, and is proxied via the primary httpd webserver.

This new deployment came with the addition of a tool for executing arbitrary commands in an arbitrary conda environment. This may be useful for seperating cog, the installer itself, and esg-publisher into their own environments.

This has been tested via a full install and a small amount of post install testing of SLCS itself.