### PR TITLE
Data only fixes

### DIFF
--- a/data_node/thredds.py
+++ b/data_node/thredds.py
@@ -101,15 +101,13 @@ def add_tomcat_user():
 
 
 def get_idp_peer_from_config():
-    node_type_list = esg_functions.get_node_type()
-    if "INDEX" in node_type_list and not set(["idp", "data", "compute"]).issubset(node_type_list):
-        try:
-            esgf_idp_peer = esg_property_manager.get_property("esgf.idp.peer")
-        except ConfigParser.NoOptionError:
-            default_idp_peer = esg_functions.get_esgf_host()
-            esgf_idp_peer = raw_input("Please specify your IDP peer node's FQDN [{}]: ".format(default_idp_peer)) or default_idp_peer
+    try:
+        esgf_idp_peer = esg_property_manager.get_property("esgf.idp.peer")
+    except ConfigParser.NoOptionError:
+        default_idp_peer = esg_functions.get_esgf_host()
+        esgf_idp_peer = raw_input("Please specify your IDP peer node's FQDN [{}]: ".format(default_idp_peer)) or default_idp_peer
 
-        return esgf_idp_peer
+    return esgf_idp_peer
 
 
 def select_idp_peer(esgf_idp_peer=None):

--- a/data_node/thredds.py
+++ b/data_node/thredds.py
@@ -120,8 +120,10 @@ def select_idp_peer(esgf_idp_peer=None):
     myproxy_endpoint = esgf_idp_peer
     esgf_host = esg_functions.get_esgf_host()
 
-    if esgf_host != myproxy_endpoint:
-        esg_truststore_manager.install_peer_node_cert(myproxy_endpoint)
+    # If issues arise where sites are not using commercial certs from
+    # trusted root certificate authorities, uncomment this and fix it
+    #if esgf_host != myproxy_endpoint:
+    #    esg_truststore_manager.install_peer_node_cert(myproxy_endpoint)
 
     esg_property_manager.set_property("esgf_idp_peer_name", esgf_idp_peer_name)
     esg_property_manager.set_property("esgf_idp_peer", esgf_idp_peer)

--- a/data_node/thredds.py
+++ b/data_node/thredds.py
@@ -120,18 +120,6 @@ def select_idp_peer(esgf_idp_peer=None):
     myproxy_endpoint = esgf_idp_peer
     esgf_host = esg_functions.get_esgf_host()
 
-    # print "Selection: [${choice}] source: ${esgf_host_ip}   dest: ${esgf_idp_peer_name}:${esgf_idp_peer}"
-    if esgf_host != esgf_idp_peer:
-        print '''
-          ----------------------------------------------------------------------
-          The IDP selected must share at least one of the peer group(s)
-          [${node_peer_group}] that this node is a member of!
-
-          run: esg-node --federation-sanity-check ${esgf_idp_peer}
-
-          for confirmation.
-          ----------------------------------------------------------------------'''
-
     if esgf_host != myproxy_endpoint:
         esg_truststore_manager.install_peer_node_cert(myproxy_endpoint)
 

--- a/esg_bootstrap.sh
+++ b/esg_bootstrap.sh
@@ -60,7 +60,7 @@ install_dependencies_pip(){
 
       pip install --upgrade pip
       pip install coloredlogs GitPython progressbar2 pyOpenSSL \
-                  lxml "requests==2.19.1" psycopg2 decorator Tempita \
+                  lxml requests psycopg2 decorator Tempita \
                   setuptools semver Pyyaml configparser psutil
       pip install -r requirements.txt
 

--- a/esgf_utilities/esg_truststore_manager.py
+++ b/esgf_utilities/esg_truststore_manager.py
@@ -10,7 +10,6 @@ import OpenSSL
 import jks
 import pybash
 import esg_functions
-from urlparse import urlparse
 from esgf_utilities import esg_property_manager
 from plumbum.commands import ProcessExecutionError
 
@@ -365,7 +364,7 @@ def install_peer_node_cert(remote_host):
 
     with pybash.pushd(config["tomcat_conf_dir"]):
         esgf_host = esg_functions.get_esgf_host()
-        ssl_endpoint = urlparse(remote_host).hostname
+        ssl_endpoint = remote_host
         ssl_port = "443"
 
         if ssl_endpoint == esgf_host:


### PR DESCRIPTION
These are changes that were made to resolve issues that arose when testing a data-only install. For now we are no longer retrieving the the IDP peers certificate to be inserted into our trust store as the tool to do this is outdated and requires manual user input. @sashakames has said sites use commercial certificates that have been signed by trusted certificate authorities.