### PR TITLE
Resolve unfound property issue.

### DIFF
--- a/base/esg_java.py
+++ b/base/esg_java.py
@@ -14,10 +14,6 @@ logger = logging.getLogger("esgf_logger" + "." + __name__)
 with open(os.path.join(os.path.dirname(__file__), os.pardir, 'esg_config.yaml'), 'r') as config_file:
     config = yaml.load(config_file)
 
-esg_root_url = esg_property_manager.get_property("esg.root.url")
-java_version = config["java_version"]
-JAVA_DIST_URL = "{}/java/{}/jdk{}-64.tar.gz".format(esg_root_url, java_version, java_version)
-
 def set_default_java():
     '''Sets the default Java binary to the version installed with ESGF'''
     esg_functions.call_binary("alternatives", ["--install", "/usr/bin/java", "/usr/local/java/bin/java", "3"])
@@ -49,8 +45,13 @@ def check_java_version(java_path=os.path.join(config["java_install_dir"], "bin",
 
 def download_java(java_tarfile):
     '''Download Java from distribution mirror'''
-    print "Downloading Java from ", JAVA_DIST_URL
-    if not esg_functions.download_update(java_tarfile, JAVA_DIST_URL):
+
+    java_url = "{0}/java/{1}/jdk{1}-64.tar.gz".format(
+        esg_property_manager.get_property("esg.root.url"),
+        config["java_version"]
+    )
+    print "Downloading Java from ", java_url
+    if not esg_functions.download_update(java_tarfile, java_url):
         logger.error("ERROR: Could not download Java")
         raise RuntimeError
 
@@ -92,8 +93,11 @@ def setup_java():
 
     pybash.mkdir_p(config["workdir"])
     with pybash.pushd(config["workdir"]):
-
-        java_tarfile = pybash.trim_string_from_head(JAVA_DIST_URL)
+        java_url = "{0}/java/{1}/jdk{1}-64.tar.gz".format(
+            esg_property_manager.get_property("esg.root.url"),
+            config["java_version"]
+        )
+        java_tarfile = pybash.trim_string_from_head(java_url)
         jdk_directory = java_tarfile.split("-")[0]
         java_install_dir_parent = config["java_install_dir"].rsplit("/", 1)[0]
 

--- a/esg_node.py
+++ b/esg_node.py
@@ -95,7 +95,7 @@ def set_esg_dist_url(install_type, script_maj_version="2.6", script_release="8")
     except ConfigParser.NoOptionError:
         selected_mirror = esg_mirror_manager.select_dist_mirror()
         esg_property_manager.set_property("esg.root.url", selected_mirror)
-        esg_property_manager.set_property("esg.dist.url", esg_property_manager.get_property("esg.root.url")+"/{}/{}".format(script_maj_version, script_release))
+        esg_property_manager.set_property("esg.dist.url", selected_mirror+"/{}/{}".format(script_maj_version, script_release))
 
 def get_installation_type(script_version):
     '''Determining if devel or master directory of the ESGF distribution mirror


### PR DESCRIPTION
The "esg.root.url" property was not being found as it was part of a global variable. This caused it to be looked for before it is populated in `esg_node.py`.