### PR TITLE
Align the requests version with that in esgprep, again

### DIFF
--- a/esg_bootstrap.sh
+++ b/esg_bootstrap.sh
@@ -60,7 +60,7 @@ install_dependencies_pip(){
 
       pip install --upgrade pip
       pip install coloredlogs GitPython progressbar2 pyOpenSSL \
-                  lxml requests psycopg2 decorator Tempita \
+                  lxml "requests==2.20.0" psycopg2 decorator Tempita \
                   setuptools semver Pyyaml configparser psutil
       pip install -r requirements.txt
 


### PR DESCRIPTION
This has become a perpetual problem. This problem could be resolved by separating the installer and publisher environments. This solution will have to be applied in the future.