### PR TITLE
moved solr version setting to esg_config.yml; resolves #686

### DIFF
--- a/esg_config.yaml
+++ b/esg_config.yaml
@@ -48,6 +48,7 @@ tomcat_major_version: '8'
 tomcat_min_version: 8.5.9
 publisher_tag: v3.5.0
 python_version: '2.7'
+solr_version: 5.5.5
 
 #Postgres constants
 pg_secret_file: /esg/config/.esg_pg_pass

--- a/index_node/solr.py
+++ b/index_node/solr.py
@@ -251,7 +251,7 @@ def setup_solr(index_config = ["master", "slave"], SOLR_INSTALL_DIR="/usr/local/
     print "******************************* \n"
 
     # # Solr/Jetty web application
-    SOLR_VERSION = "5.5.5"
+    SOLR_VERSION = config["solr_version"]
     os.environ["SOLR_HOME"] = SOLR_HOME
     SOLR_INCLUDE= "{SOLR_HOME}/solr.in.sh".format(SOLR_HOME=SOLR_HOME)
     solr_config_types = index_config


### PR DESCRIPTION
The solr version was being stored in the solr.py file instead of the esg_config.yaml file.  This deviated from the rest of the version tracking so the solr version was moved to esg_config.yaml