### PR TITLE
removed the trailing slash; #resolves #704

### DIFF
--- a/esg_node.py
+++ b/esg_node.py
@@ -43,7 +43,7 @@ def set_env_variables():
     os.environ["PGUSER"] = "dbsuper"
     os.environ["PGHOST"] = "localhost"
     os.environ["PGPORT"] = "5432"
-    os.environ["JAVA_HOME"] = "/usr/local/java/"
+    os.environ["JAVA_HOME"] = "/usr/local/java"
     os.environ["CATALINA_HOME"] = "/usr/local/tomcat"
     os.environ["CATALINA_BASE"] = "/usr/local/tomcat"
 


### PR DESCRIPTION
This fixes the problem that @muryanto1 reported yesterday with the ESG Search and Solr pings failing in the test suite.